### PR TITLE
Control Objective - Set approved instance and engine types #60

### DIFF
--- a/control_objectives/aws_rds_db_approved/README.md
+++ b/control_objectives/aws_rds_db_approved/README.md
@@ -12,8 +12,8 @@ To create the smart folder, you must have:
 
 ## Running the Example
 
-To run the S3 Example:
-- Navigate to the directory on the command line `cd s3_smartfolder_example`
+To run the RDS Example:
+- Navigate to the directory on the command line `cd aws_rds_db_approved`
 - Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
 - Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
 

--- a/control_objectives/aws_rds_db_approved/README.md
+++ b/control_objectives/aws_rds_db_approved/README.md
@@ -1,0 +1,20 @@
+# RDS Instance/ Engine approved
+
+Provides a Terraform configuration for creating a smart folder and applying example turbot policy settings for an RDS instance. The policies will check if an instance is approved based on engine type and instance type.
+
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://github.com/turbotio/terraform-provider-turbot)
+- Credentials Configured to connect to your Turbot workspace
+
+## Running the Example
+
+To run the S3 Example:
+- Navigate to the directory on the command line `cd s3_smartfolder_example`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
+
+> The baseline runs with the default values. However, you could create and set your own defaults using `.tfvars` file that will override the existing files.

--- a/control_objectives/aws_rds_db_approved/README.md
+++ b/control_objectives/aws_rds_db_approved/README.md
@@ -17,4 +17,4 @@ To run the S3 Example:
 - Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
 - Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
 
-> The baseline runs with the default values. However, you could create and set your own defaults using `.tfvars` file that will override the existing files.
+> The terraform plan runs with default values. Ensure the policy values are correct in main.tf before applying the plan.

--- a/control_objectives/aws_rds_db_approved/default.tfvars
+++ b/control_objectives/aws_rds_db_approved/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "RDS DB Engine/ Instance Approved"

--- a/control_objectives/aws_rds_db_approved/main.tf
+++ b/control_objectives/aws_rds_db_approved/main.tf
@@ -14,12 +14,13 @@ resource "turbot_smart_folder" "rds_engine_instance_type_approved" {
 
 }
 
-#RDS Engines approved (Define engines, aurora, mariaDB, postgreSQL here as examples)
+#RDS Engines approved (Define engines, aurora, mariaDB, postgreSQL here as examples). ENGINES MUST BE LOWER CASE
 # AWS > RDS > DB Instance > Approved > Database Engines
+
  resource "turbot_policy_setting" "rds_db_approved_engine" {
   resource = turbot_smart_folder.rds_engine_instance_type_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedDatabaseEngines"
-  value = yamlencode(["aurora","mariaDB","postgreSQL"])
+  value = yamlencode(["aurora","mariadb","postgresql"])
 }
 
 #RDS Instance Classes (Define instances, db.t3.* and db.m5.2xlarge as examples)

--- a/control_objectives/aws_rds_db_approved/main.tf
+++ b/control_objectives/aws_rds_db_approved/main.tf
@@ -1,8 +1,14 @@
 # RDS DB Instance Approved
 
+resource "turbot_smart_folder" "rds_engine_instance_type_approved" {
+  title         = var.smart_folder_title
+  description   = "Create a smart folder to apply the RDS policy settings"
+  parent        = "tmod:@turbot/turbot#/"
+}
+
 # AWS > RDS > DB Instance > Approved 
  resource "turbot_policy_setting" "rds_db_approved" {
-  resource = turbot_smart_folder.rds_instance_approved.id
+  resource = turbot_smart_folder.rds_engine_instance_type_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApproved"
   value = "Check: Approved"
 
@@ -11,7 +17,7 @@
 #RDS Engines approved (Define engines, aurora, mariaDB, postgreSQL here as examples)
 # AWS > RDS > DB Instance > Approved > Database Engines
  resource "turbot_policy_setting" "rds_db_approved_engine" {
-  resource = turbot_smart_folder.rds_instance_approved.id
+  resource = turbot_smart_folder.rds_engine_instance_type_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedDatabaseEngines"
   value = yamlencode(["aurora","mariaDB","postgreSQL"])
 }
@@ -19,7 +25,7 @@
 #RDS Instance Classes (Define instances, db.t3.* and db.m5.2xlarge as examples)
 # AWS > RDS > DB Instance > Approved > Instance Classes
  resource "turbot_policy_setting" "rds_db_approved_instancetypes" {
-  resource = turbot_smart_folder.rds_instance_approved.id
+  resource = turbot_smart_folder.rds_engine_instance_type_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedInstanceClasses"
   value = yamlencode(["db.t3.*","db.m5.2xlarge"])
 }

--- a/control_objectives/aws_rds_db_approved/main.tf
+++ b/control_objectives/aws_rds_db_approved/main.tf
@@ -2,7 +2,7 @@
 
 # AWS > RDS > DB Instance > Approved 
  resource "turbot_policy_setting" "rds_db_approved" {
-  resource = turbot_smart_folder.va_rds.id
+  resource = turbot_smart_folder.rds_instance_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApproved"
   value = "Check: Approved"
 
@@ -11,7 +11,7 @@
 #RDS Engines approved (Define engines, aurora, mariaDB, postgreSQL here as examples)
 # AWS > RDS > DB Instance > Approved > Database Engines
  resource "turbot_policy_setting" "rds_db_approved_engine" {
-  resource = turbot_smart_folder.va_rds.id
+  resource = turbot_smart_folder.rds_instance_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedDatabaseEngines"
   value = yamlencode(["aurora","mariaDB","postgreSQL"])
 }
@@ -19,7 +19,7 @@
 #RDS Instance Classes (Define instances, db.t3.* and db.m5.2xlarge as examples)
 # AWS > RDS > DB Instance > Approved > Instance Classes
  resource "turbot_policy_setting" "rds_db_approved_instancetypes" {
-  resource = turbot_smart_folder.va_rds.id
+  resource = turbot_smart_folder.rds_instance_approved.id
   type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedInstanceClasses"
   value = yamlencode(["db.t3.*","db.m5.2xlarge"])
 }

--- a/control_objectives/aws_rds_db_approved/main.tf
+++ b/control_objectives/aws_rds_db_approved/main.tf
@@ -1,0 +1,25 @@
+# RDS DB Instance Approved
+
+# AWS > RDS > DB Instance > Approved 
+ resource "turbot_policy_setting" "rds_db_approved" {
+  resource = turbot_smart_folder.va_rds.id
+  type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApproved"
+  value = "Check: Approved"
+
+}
+
+#RDS Engines approved (Define engines, aurora, mariaDB, postgreSQL here as examples)
+# AWS > RDS > DB Instance > Approved > Database Engines
+ resource "turbot_policy_setting" "rds_db_approved_engine" {
+  resource = turbot_smart_folder.va_rds.id
+  type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedDatabaseEngines"
+  value = yamlencode(["aurora","mariaDB","postgreSQL"])
+}
+
+#RDS Instance Classes (Define instances, db.t3.* and db.m5.2xlarge as examples)
+# AWS > RDS > DB Instance > Approved > Instance Classes
+ resource "turbot_policy_setting" "rds_db_approved_instancetypes" {
+  resource = turbot_smart_folder.va_rds.id
+  type = "tmod:@turbot/aws-rds#/policy/types/dbInstanceApprovedInstanceClasses"
+  value = yamlencode(["db.t3.*","db.m5.2xlarge"])
+}

--- a/control_objectives/aws_rds_db_approved/variables.tf
+++ b/control_objectives/aws_rds_db_approved/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = "string"
+    description = "Enter a title for the smart folder"
+}

--- a/control_objectives/aws_rds_db_approved/variables.tf
+++ b/control_objectives/aws_rds_db_approved/variables.tf
@@ -1,4 +1,4 @@
 variable "smart_folder_title" {
-    type        = "string"
+    type        = string
     description = "Enter a title for the smart folder"
 }


### PR DESCRIPTION
AWS RDS control objective to check RDS approval based on instance/ engine type

closes #60 