### PR TITLE
GraphQL Query - List AWS resource and associated policies and controls #58

### DIFF
--- a/api_examples/graphql/queries/resource_control_policy.graphql
+++ b/api_examples/graphql/queries/resource_control_policy.graphql
@@ -1,0 +1,34 @@
+query ResourceControlPolicyQuery {
+  resources(paging: "", filter: "resourceType:'tmod:@turbot/aws#/resource/types/aws'") {
+    items {
+      data
+      controls(filter: "state:alarm,error,ok") {
+        items {
+          reason
+          state
+          turbot {
+            dependencies {
+              policyValues {
+                items {
+                  state
+                  value
+                  type {
+                    modUri
+                    description
+                    categoryUri
+                    input
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    metadata {
+      stats {
+        total
+      }
+    }
+  }
+}


### PR DESCRIPTION
Initial commit of a query that lists each AWS resource, then the controls and policies associated with that resource.

closes #58 