### PR TITLE
Base Line - Fixed spelling in Azure default.tfvars file #64

### DIFF
--- a/baselines/azure/azure_sub_import/default.tfvars
+++ b/baselines/azure/azure_sub_import/default.tfvars
@@ -4,7 +4,7 @@ azure_app_name                 = "<app_name>"
 
 azure_app_password             = "<password>"
 
-azure_environment_type         = "<clound_environment>"
+azure_environment_type         = "<cloud_environment>"
 
 azure_subscription_id          = "<azure_subscription_id>"
 


### PR DESCRIPTION
Changed spelling of clound_environment to cloud_environment.

closes #63