### PR TITLE
Control Objective - EC2 enforcement of encryption on volumes and snapshots #73

### DIFF
--- a/control_objectives/aws_ec2_enforce_encryption/README.md
+++ b/control_objectives/aws_ec2_enforce_encryption/README.md
@@ -1,0 +1,20 @@
+# AWS EC2 enforce encryption on snapshots and volumes
+
+Provides a Terraform configuration for creating a smart folder and creating policies to check volumes and snapshots for encryption, as well as enabling the EC2 > Volume > Approved and EC2 > Snapshot > Approved policies. The approved policies will generate alarms if volumes or snapshots violate the encryption requirement.
+
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://github.com/turbotio/terraform-provider-turbot)
+- Credentials configured to connect to your Turbot workspace
+
+## Running the Example
+
+To run the EC2 encryption enforcement Example:
+- Navigate to the directory on the command line `cd aws_rds_encryption_at_rest`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
+
+> The terraform plan sets the policy to check for AWS managed key or higher. Alternate values include: `None`, `None or higher`, `AWS managed key`, `AWS managed key or higher`, `Customer managed key`, and `Encryption at Rest > Customer Managed Key`.

--- a/control_objectives/aws_ec2_enforce_encryption/README.md
+++ b/control_objectives/aws_ec2_enforce_encryption/README.md
@@ -12,7 +12,7 @@ To create the smart folder, you must have:
 
 ## Running the Example
 
-To run the EC2 encryption enforcement Example:
+To run the EC2 encryption enforcement example:
 - Navigate to the directory on the command line `cd aws_rds_encryption_at_rest`
 - Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
 - Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings

--- a/control_objectives/aws_ec2_enforce_encryption/default.tfvars
+++ b/control_objectives/aws_ec2_enforce_encryption/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "EC2 enforce snapshot and volume encryption"

--- a/control_objectives/aws_ec2_enforce_encryption/main.tf
+++ b/control_objectives/aws_ec2_enforce_encryption/main.tf
@@ -1,0 +1,37 @@
+# EC2 encryption enforcement folder
+
+resource "turbot_smart_folder" "ec2_encryption" {
+  title         = var.smart_folder_title
+  description   = "Create a smart folder and set snapshot encryption and volume encryption policies"
+  parent        = "tmod:@turbot/turbot#/"
+}
+
+# AWS > EC2 > Snapshot > Approved
+resource "turbot_policy_setting" "ec2_snapshot_approved" {
+  resource = turbot_smart_folder.ec2_encryption.id
+  type = "tmod:@turbot/aws-ec2#/policy/types/snapshotApproved"
+  value = "Check: Approved"
+}
+
+# AWS > EC2 > Snapshot > Approved
+resource "turbot_policy_setting" "ec2_volume_approved" {
+  resource = turbot_smart_folder.ec2_encryption.id
+  type = "tmod:@turbot/aws-ec2#/policy/types/volumeApproved"
+  value = "Check: Approved"
+}
+
+# Enforce Block Storage Encryption
+# AWS > EC2 > Volume > Approved > Encryption at Rest
+resource "turbot_policy_setting" "ec2_volume_approved_encryption" {
+  resource = turbot_smart_folder.ec2_encryption.id
+  type = "tmod:@turbot/aws-ec2#/policy/types/volumeEncryptionAtRest"
+  value = "AWS managed key or higher"
+}
+
+# Enforce Snapshot/Backup Encryption
+# AWS > EC2 > Snapshot > Approved > Encryption at Rest
+resource "turbot_policy_setting" "ec2_snapshot_approved_encryption" {
+  resource = turbot_smart_folder.ec2_encryption.id
+  type = "tmod:@turbot/aws-ec2#/policy/types/snapshotEncryptionAtRest"
+  value = "AWS managed key or higher"
+}

--- a/control_objectives/aws_ec2_enforce_encryption/variables.tf
+++ b/control_objectives/aws_ec2_enforce_encryption/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = string
+    description = "Enter a title for the smart folder"
+}


### PR DESCRIPTION
Control objective to create two policies that check for approval on snapshots and volumes, and then also creates two policies that alarm the approved control if encryption is not set at `AWS managed key or higher`.

closes #73