### PR TITLE
Control Objective - Turbot Service Roles #111

### DIFF
--- a/control_objectives/aws_iam_turbot_service_roles/README.md
+++ b/control_objectives/aws_iam_turbot_service_roles/README.md
@@ -1,0 +1,18 @@
+# AWS IAM Turbot Service Role configuration check
+
+Provides a Terraform configuration for creating a smart folder and creating one policy to check the existence of Turbot service roles in an AWS account, and three subsequent policies that define which roles to check.
+
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://github.com/turbotio/terraform-provider-turbot)
+- Credentials Configured to connect to your Turbot workspace
+
+## Running the Example
+
+To run the AWS IAM Turbot Service Role Configuration Check:
+- Navigate to the directory on the command line `aws_iam_turbot_service_roles`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings

--- a/control_objectives/aws_iam_turbot_service_roles/default.tfvars
+++ b/control_objectives/aws_iam_turbot_service_roles/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "Turbot AWS IAM Roles"

--- a/control_objectives/aws_iam_turbot_service_roles/main.tf
+++ b/control_objectives/aws_iam_turbot_service_roles/main.tf
@@ -1,0 +1,39 @@
+# Create smart folder for policies
+resource "turbot_smart_folder" "turbot_service_roles" {
+    title       = var.smart_folder_title
+    description = "Policies to check if Configuration Recording role, EC2 default role, and Flow logging role exist in attached accounts." 
+    parent      = "tmod:@turbot/turbot#/"
+}
+
+# AWS > Turbot > Service Roles
+# Check if the below roles are configured
+resource "turbot_policy_setting" "turbot_serviceroles_configured" {
+    resource = turbot_smart_folder.turbot_service_roles.id
+    type = "tmod:@turbot/aws#/policy/types/serviceRoles"
+    value = "Check: Configured"
+}
+
+# Turbot Config Recorder Role
+# AWS > Turbot > Service Roles > Configurtation Recording
+resource "turbot_policy_setting" "turbot_cr_configured" {
+    resource = turbot_smart_folder.turbot_service_roles.id
+    type = "tmod:@turbot/aws#/policy/types/serviceRolesConfigurationRecording"
+    value = "Enabled"
+}
+
+
+# Turbot Default EC2 Instance Role
+# AWS > Turbot > Service Roles > Default EC2 Instance 
+resource "turbot_policy_setting" "turbot_sr_defaultec2" {
+    resource = turbot_smart_folder.turbot_service_roles.id
+    type = "tmod:@turbot/aws#/policy/types/serviceRolesDefaultEc2Instance"
+    value = "Enabled"
+}
+
+# Turbot Default VPC Flow Log Role
+# AWS > Turbot > Service Roles > Flow Logging 
+resource "turbot_policy_setting" "turbot_sr_flowlogs" {
+    resource = turbot_smart_folder.turbot_service_roles.id
+    type = "tmod:@turbot/aws#/policy/types/serviceRolesFlowLogging"
+    value = "Enabled"
+}

--- a/control_objectives/aws_iam_turbot_service_roles/variables.tf
+++ b/control_objectives/aws_iam_turbot_service_roles/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = string
+    description = "Enter a title for the smart folder"
+}


### PR DESCRIPTION
Provides a Terraform configuration for creating a smart folder and creating one policy to check the existence of Turbot service roles in an AWS account, and three subsequent policies that define which roles to check.

closes #111