### PR TITLE
Control Objective - Restrict NAT Gateway within VPC #115

### DIFF
--- a/control_objectives/aws_vpc_restrict_nat/README.md
+++ b/control_objectives/aws_vpc_restrict_nat/README.md
@@ -1,0 +1,18 @@
+# AWS VPC Restrict NAT Usage
+
+Provides a Terraform configuration for creating a smart folder and applying example turbot policy settings to restrict NAT Gateway usage. 
+
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://github.com/turbotio/terraform-provider-turbot)
+- Credentials configured to connect to your Turbot workspace
+
+## Running the Example
+
+To run the AWS VPC Restrict NAT Usage example:
+- Navigate to the directory on the command line `cd aws_vpc_restrict_nat`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings

--- a/control_objectives/aws_vpc_restrict_nat/default.tfvars
+++ b/control_objectives/aws_vpc_restrict_nat/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "AWS VPC Restrict NAT Usage"

--- a/control_objectives/aws_vpc_restrict_nat/main.tf
+++ b/control_objectives/aws_vpc_restrict_nat/main.tf
@@ -1,0 +1,22 @@
+# Create smart folder
+resource "turbot_smart_folder" "vpc_restrict_nat" {
+  title         = var.smart_folder_title
+  description   = "Create a smart folder to apply the s3 policy settings"
+  parent        = "tmod:@turbot/turbot#/"
+}
+
+# Setting NAT Usage Policies. This can also be set to `Enforce: Delete unapproved if new`
+# AWS > VPC > NAT Gateway > Approved
+resource "turbot_policy_setting" "vpc_natgw_approved" {
+    resource = turbot_smart_folder.vpc_restrict_nat.id
+    type = "tmod:@turbot/aws-vpc-internet#/policy/types/natGatewayApproved"
+    value = "Check: Approved"
+}
+
+# Set approval check to not approved.
+# AWS > VPC > NAT Gateway > Approved > Usage
+resource "turbot_policy_setting" "vpc_natgw_approved_usage" {
+    resource = turbot_smart_folder.vpc_restrict_nat.id
+    type = "tmod:@turbot/aws-vpc-internet#/policy/types/natGatewayApprovedUsage"
+    value = "Not approved"
+}

--- a/control_objectives/aws_vpc_restrict_nat/variables.tf
+++ b/control_objectives/aws_vpc_restrict_nat/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = string
+    description = "Enter a title for the smart folder"
+}


### PR DESCRIPTION
Provides a Terraform configuration for creating a smart folder and applying example turbot policy settings to restrict NAT Gateway usage. 

closes #115