### PR TITLE
Control Objective - Turbot IAM Roles #113

### DIFF
--- a/control_objectives/turbot_iam_roles/README.md
+++ b/control_objectives/turbot_iam_roles/README.md
@@ -1,0 +1,18 @@
+# Turbot AWS IAM Roles
+
+Provides a Terraform configuration for creating a smart folder and sets a policy to enable Turbot creating AWS IAM roles. Two policies are also created to check for AWS boundary policies.
+
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://github.com/turbotio/terraform-provider-turbot)
+- Credentials Configured to connect to your Turbot workspace
+
+## Running the Example
+
+To run the Turbot AWS IAM Roles:
+- Navigate to the directory on the command line `turbot_iam_roles`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings

--- a/control_objectives/turbot_iam_roles/default.tfvars
+++ b/control_objectives/turbot_iam_roles/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "AWS IAM Turbot Service Roles"

--- a/control_objectives/turbot_iam_roles/main.tf
+++ b/control_objectives/turbot_iam_roles/main.tf
@@ -1,0 +1,41 @@
+# Create smart folder for policies
+resource "turbot_smart_folder" "turbot_iam_roles" {
+    title       = var.smart_folder_title
+    description = "Create Turbot IAM roles as well as checking for boundary policies"
+    parent      = "tmod:@turbot/turbot#/"
+}
+
+# Create Turbot IAM Roles
+# AWS > Turbot > Permissions
+resource "turbot_policy_setting" "turbot_permissions_iam" {
+    resource = turbot_smart_folder.turbot_iam_roles.id
+    type = "tmod:@turbot/aws-iam#/policy/types/permissions"
+    value = "Enforce: Role Mode"
+}
+
+# Set Turbot IAM Roles Levels
+# AWS > Turbot > Permissions > Levels
+resource "turbot_policy_setting" "turbot_permissions_iamlevels" {
+    resource = turbot_smart_folder.turbot_iam_roles.id
+    type = "tmod:@turbot/aws-iam#/policy/types/permissionsLevels"
+    value = yamlencode(["AWS/User","AWS/Metadata","AWS/Readonly","AWS/Operator","AWS/Admin","AWS/Owner","AWS/SuperUser"])
+}
+
+
+### Boundary / Lockdowns
+
+# Boundary for Roles
+# AWS > IAM > Role > Boundary
+resource "turbot_policy_setting" "turbot_role_boundary_iam" {
+    resource = turbot_smart_folder.turbot_iam_roles.id
+    type = "tmod:@turbot/aws-iam#/policy/types/roleBoundary"
+    value = "Check: Boundary > Policy"
+}
+
+# Boundary for Users
+# AWS > IAM > Users > Boundary
+resource "turbot_policy_setting" "turbot_user_boundary_iam" {
+    resource = turbot_smart_folder.turbot_iam_roles.id
+    type = "tmod:@turbot/aws-iam#/policy/types/userBoundary"
+    value = "Check: Boundary > Policy"
+}

--- a/control_objectives/turbot_iam_roles/variables.tf
+++ b/control_objectives/turbot_iam_roles/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = string
+    description = "Enter a title for the smart folder"
+}


### PR DESCRIPTION
Provides a Terraform configuration for creating a smart folder and sets a policy to enable Turbot creating AWS IAM roles. Two policies are also created to check for AWS boundary policies.

closes #113