### PR TITLE
Calculated Policy - Alarm if EC2 instance is in public subnet #129

### DIFF
--- a/calculated_policies/aws_ec2_public_subnet/README.md
+++ b/calculated_policies/aws_ec2_public_subnet/README.md
@@ -1,12 +1,15 @@
 # AWS EC2 Instance Not Approved if Public Subnet
 
 ## User Story
+
 There is an organizational requirement that in specific accounts, no EC2 instance can be booted within a subnet with an associated route table which has routes pointing to an Internet Gateway (IGW).
 
 ## Implementation Details
+
 This script provides a Terraform configuration for creating a smart folder and applying a calculated policy using `AWS > EC2 > Instance > Approved > Usage` policy, and then setting `AWS > EC2 > Instance > Approved` to check. T
 
 ### Template Input (GraphQL)
+
 The template input to a calculated policy is a GraphQL query.  This query is two-fold. First, it finds the subnet ID contained within the EC2 instance metadata. Second, all route tables in the account are found, and the associated subnet ID as well as the collection of routes :
 ```graphql
 {
@@ -22,6 +25,7 @@ The template input to a calculated policy is a GraphQL query.  This query is two
 }
 ```
 ### Template (Nunjucks)
+
 The template itself is a [Nunjucks formatted template](https://mozilla.github.io/nunjucks/templating.html) with custom logic:
 ```js
 {%- set hasIGW = false -%}
@@ -52,8 +56,8 @@ To create the smart folder, you must have:
 ## Running the Example
 
 To run the template:
-- Navigate to the directory on the command line `cd aws_ec2_public_subnet`
-- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
-- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
+1. Navigate to the directory on the command line `cd aws_ec2_public_subnet`
+2. Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+3. Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
 
-> The template will run with the default values set in `default.tfvars`; however, you could create and set your own defaults using a `.tfvars` file that will override the existing files.
+The template will run using the default values defined [default.tfvars](default.tfvars)

--- a/calculated_policies/aws_ec2_public_subnet/README.md
+++ b/calculated_policies/aws_ec2_public_subnet/README.md
@@ -1,0 +1,59 @@
+# AWS EC2 Instance Not Approved if Public Subnet
+
+## User Story
+There is an organizational requirement that in specific accounts, no EC2 instance can be booted within a subnet with an associated route table which has routes pointing to an Internet Gateway (IGW).
+
+## Implementation Details
+This script provides a Terraform configuration for creating a smart folder and applying a calculated policy using `AWS > EC2 > Instance > Approved > Usage` policy, and then setting `AWS > EC2 > Instance > Approved` to check. T
+
+### Template Input (GraphQL)
+The template input to a calculated policy is a GraphQL query.  This query is two-fold. First, it finds the subnet ID contained within the EC2 instance metadata. Second, all route tables in the account are found, and the associated subnet ID as well as the collection of routes :
+```graphql
+{
+  resource {
+    subnetId: get(path: "SubnetId")
+  }
+  resources(filter:"resourceType:'tmod:@turbot/aws-vpc-core#/resource/types/routeTable'") {
+    items {
+      associations: get(path: "Associations.[0].SubnetId")
+      routes: get(path: "Routes")
+    }
+  }
+}
+```
+### Template (Nunjucks)
+The template itself is a [Nunjucks formatted template](https://mozilla.github.io/nunjucks/templating.html) with custom logic:
+```js
+{%- set hasIGW = false -%}
+{%- for item in $.resources.items -%}
+  {%- if item.associations == $.resource.subnetId -%}
+    {%- for gateway in item.routes -%}
+      {%- if 'igw' in gateway.GatewayId -%}
+        {%- if hasIGW == false -%}
+          "Not approved"
+          {%- set hasIGW = true -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if hasIGW == false -%}
+  "Approved if AWS > EC2 > Enabled"
+{%- endif -%}
+```
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://github.com/turbotio/terraform-provider-turbot)
+- Credentials Configured to connect to your Turbot workspace
+
+## Running the Example
+
+To run the template:
+- Navigate to the directory on the command line `cd aws_ec2_public_subnet`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
+
+> The template will run with the default values set in `default.tfvars`; however, you could create and set your own defaults using a `.tfvars` file that will override the existing files.

--- a/calculated_policies/aws_ec2_public_subnet/default.tfvars
+++ b/calculated_policies/aws_ec2_public_subnet/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "EC2 in Public Subnet"

--- a/calculated_policies/aws_ec2_public_subnet/default.tfvars
+++ b/calculated_policies/aws_ec2_public_subnet/default.tfvars
@@ -1,1 +1,2 @@
-smart_folder_title = "EC2 in Public Subnet"
+# Optional
+# smart_folder_title = "EC2 in Public Subnet"

--- a/calculated_policies/aws_ec2_public_subnet/main.tf
+++ b/calculated_policies/aws_ec2_public_subnet/main.tf
@@ -1,0 +1,50 @@
+resource "turbot_smart_folder" "ec2_public_subnet" {
+  title         = var.smart_folder_title
+  description   = "Set any instance to 'Not Approved' if the instance is in a public subnet"
+  parent        = "tmod:@turbot/turbot#/"
+}
+
+resource "turbot_policy_setting" "instance_approved" {
+  resource   = turbot_smart_folder.ec2_public_subnet.id
+  type       = "tmod:@turbot/aws-ec2#/policy/types/instanceApproved"
+  value      = "Check: Approved"
+}
+
+resource "turbot_policy_setting" "instance_subnet_" {
+  resource   = turbot_smart_folder.ec2_public_subnet.id
+  type       = "tmod:@turbot/aws-ec2#/policy/types/instanceApprovedUsage"
+  # GraphQL to pull instance tags
+  template_input = <<EOT
+{
+  resource {
+    subnetId: get(path: "SubnetId")
+  }
+  resources(filter:"resourceType:'tmod:@turbot/aws-vpc-core#/resource/types/routeTable'") {
+    items {
+      associations: get(path: "Associations.[0].SubnetId")
+      routes: get(path: "Routes")
+    }
+  }
+}
+  EOT
+  
+  # Nunjucks Template
+  template      = <<EOT
+{%- set hasIGW = false -%}
+{%- for item in $.resources.items -%}
+  {%- if item.associations == $.resource.subnetId -%}
+    {%- for gateway in item.routes -%}
+      {%- if 'igw' in gateway.GatewayId -%}
+        {%- if hasIGW == false -%}
+          "Not approved"
+          {%- set hasIGW = true -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if hasIGW == false -%}
+  "Approved if AWS > EC2 > Enabled"
+{%- endif -%}
+  EOT
+}

--- a/calculated_policies/aws_ec2_public_subnet/main.tf
+++ b/calculated_policies/aws_ec2_public_subnet/main.tf
@@ -15,36 +15,36 @@ resource "turbot_policy_setting" "instance_subnet_" {
   type       = "tmod:@turbot/aws-ec2#/policy/types/instanceApprovedUsage"
   # GraphQL to pull instance tags
   template_input = <<EOT
-{
-  resource {
-    subnetId: get(path: "SubnetId")
-  }
-  resources(filter:"resourceType:'tmod:@turbot/aws-vpc-core#/resource/types/routeTable'") {
-    items {
-      associations: get(path: "Associations.[0].SubnetId")
-      routes: get(path: "Routes")
+  {
+    resource {
+      subnetId: get(path: "SubnetId")
+    }
+    resources(filter:"resourceType:'tmod:@turbot/aws-vpc-core#/resource/types/routeTable'") {
+      items {
+        associations: get(path: "Associations.[0].SubnetId")
+        routes: get(path: "Routes")
+      }
     }
   }
-}
   EOT
   
   # Nunjucks Template
   template      = <<EOT
-{%- set hasIGW = false -%}
-{%- for item in $.resources.items -%}
-  {%- if item.associations == $.resource.subnetId -%}
-    {%- for gateway in item.routes -%}
-      {%- if 'igw' in gateway.GatewayId -%}
-        {%- if hasIGW == false -%}
-          "Not approved"
-          {%- set hasIGW = true -%}
+  {%- set hasIGW = false -%}
+  {%- for item in $.resources.items -%}
+    {%- if item.associations == $.resource.subnetId -%}
+      {%- for gateway in item.routes -%}
+        {%- if 'igw' in gateway.GatewayId -%}
+          {%- if hasIGW == false -%}
+            "Not approved"
+            {%- set hasIGW = true -%}
+          {%- endif -%}
         {%- endif -%}
-      {%- endif -%}
-    {%- endfor -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- if hasIGW == false -%}
+    "Approved if AWS > EC2 > Enabled"
   {%- endif -%}
-{%- endfor -%}
-{%- if hasIGW == false -%}
-  "Approved if AWS > EC2 > Enabled"
-{%- endif -%}
   EOT
 }

--- a/calculated_policies/aws_ec2_public_subnet/variables.tf
+++ b/calculated_policies/aws_ec2_public_subnet/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = "string"
+    description = "Enter a title for the smart folder"
+}

--- a/calculated_policies/aws_ec2_public_subnet/variables.tf
+++ b/calculated_policies/aws_ec2_public_subnet/variables.tf
@@ -1,4 +1,5 @@
 variable "smart_folder_title" {
-    type        = "string"
+    type        = string
     description = "Enter a title for the smart folder"
+    default     = "EC2 in Public Subnet" 
 }


### PR DESCRIPTION
New calculated policy that alarms if an EC2 instance is in a subnet that has an associated route table, and that route table contains a route to an IGW.

closes #129