### PR TITLE
Control Objective - AWS VPC Security Group Rules check #166

### DIFF
--- a/control_objectives/aws_vpc_security_group_rules/README.md
+++ b/control_objectives/aws_vpc_security_group_rules/README.md
@@ -1,0 +1,20 @@
+# AWS VPC Security Group Rules check
+
+Provides a Terraform configuration for creating a smart folder and policies that check security group rules. If rules violate what is set in the policy, Turbot controls will go into the alarm state.
+
+
+## Pre-requisites
+
+To create the smart folder, you must have:
+- [Terraform](https://www.terraform.io) Version 12
+- [Turbot Terraform Provider](https://turbot.com/v5/docs/reference/terraform)
+- [Credentials configured](https://turbot.com/v5/docs/reference/cli/installation#setup-your-turbot-credentials) to connect to your Turbot workspace
+
+## Running the Example
+
+To run the AWS VPC Security Group Rules check example:
+- Navigate to the directory on the command line `cd aws_vpc_security_group_rules`
+- Run `terraform plan -var-file="default.tfvars"` and review the changes to be applied
+- Run `terraform apply -var-file="default.tfvars"` to execute and apply the policy settings
+
+Keep in mind that the security group rule policies are examples only! They must be modified to match organizational requirements.

--- a/control_objectives/aws_vpc_security_group_rules/default.tfvars
+++ b/control_objectives/aws_vpc_security_group_rules/default.tfvars
@@ -1,0 +1,1 @@
+smart_folder_title = "AWS VPC Security Group Rules"

--- a/control_objectives/aws_vpc_security_group_rules/main.tf
+++ b/control_objectives/aws_vpc_security_group_rules/main.tf
@@ -1,0 +1,36 @@
+# VPC Security Group Rules check 
+
+resource "turbot_smart_folder" "vpc_sg_rule_check" {
+  title         = var.smart_folder_title
+  description   = "Create a smart folder and security group rule check policies"
+  parent        = "tmod:@turbot/turbot#/"
+}
+
+# REJECTING 22, 3389 ingress from public internet 0.0.0.0/0 and ipv6 ::/0
+# APPROVING rds default ports of 1433, 1521, 3306, 5432 from 10.0.0.0/8 are allowed
+# APPROVING 80 and 443 are allowed egress to 0.0.0.0/0 but nothing else
+# Also AWS CIS v1.2 Section 4.01 Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 (Scored) and # 4.02 Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 (Scored)
+
+resource "turbot_policy_setting" "security_group_ingress_rules_approved_rules"{
+  resource = turbot_smart_folder.vpc_sg_rule_check.id
+  type = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupIngressRulesApprovedRules"
+  value = "REJECT $.turbot.ports.+:22,3389 $.turbot.cidr:0.0.0.0/0,::/0\nAPPROVE $.turbot.ports.+:1433,1521,3306,5432 $.turbot.cidr:<=10.0.0.0/8\nREJECT *"
+}
+
+resource "turbot_policy_setting" "security_group_egress_rules_approved_rules"{
+  resource = turbot_smart_folder.vpc_sg_rule_check.id
+  type = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupEgressRulesApprovedRules"
+  value = "APROVE $.turbot.ports.+:80,443 $.turbot.cidr:0.0.0.0/0,::/0\nREJECT *"
+}
+
+resource "turbot_policy_setting" "security_group_ingress_rules_approved"{
+  resource = turbot_smart_folder.vpc_sg_rule_check.id
+  type = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupIngressRulesApproved"
+  value = "Check: Approved"
+}
+
+resource "turbot_policy_setting" "security_group_egress_rules_approved"{
+  resource = turbot_smart_folder.vpc_sg_rule_check.id
+  type = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupEgressRulesApproved"
+  value = "Check: Approved"
+}

--- a/control_objectives/aws_vpc_security_group_rules/variables.tf
+++ b/control_objectives/aws_vpc_security_group_rules/variables.tf
@@ -1,0 +1,4 @@
+variable "smart_folder_title" {
+    type        = string
+    description = "Enter a title for the smart folder"
+}


### PR DESCRIPTION
closes #166

REJECTING 22, 3389 ingress from public internet 0.0.0.0/0 and ipv6 ::/0
APPROVING rds default ports of 1433, 1521, 3306, 5432 from 10.0.0.0/8 are allowed
APPROVING 80 and 443 are allowed egress to 0.0.0.0/0 but nothing else
Also AWS CIS v1.2 Section 4.01 Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 (Scored) and # 4.02 Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 (Scored)

>Keep in mind that the security group rule policies are examples only! They must be modified to match organizational requirements.
