### PR TITLE
Fixed resource definition

### DIFF
--- a/baselines/gcp/gcp_project_import/main.tf
+++ b/baselines/gcp/gcp_project_import/main.tf
@@ -13,13 +13,13 @@ resource "turbot_resource" "project_resource" {
 }
 
 resource "turbot_policy_setting" "clientEmail" {
-  resource = var.parent_resource
+  resource = var.project_resource.id
   type     = "tmod:@turbot/gcp#/policy/types/clientEmail"
   value    = var.client_email
 }
 
 resource "turbot_policy_setting" "privateKey" {
-  resource = var.parent_resource
+  resource = var.project_resource.id
   type     = "tmod:@turbot/gcp#/policy/types/privateKey"
   value    = var.private_key
 }


### PR DESCRIPTION
Previously, the resource field was calling the parent_resource variable. Changed it to align with the other import terraform files and correctly call the project Turbot ID.