### PR TITLE
Clean AWS baseline TF files to remove default and readme updates. Closes #441

### DIFF
--- a/baselines/getting_started/aws/aws_check_cost_controls/README.md
+++ b/baselines/getting_started/aws/aws_check_cost_controls/README.md
@@ -52,6 +52,12 @@ terraform init
 terraform apply --var-file demo.tfvars
 ```
 
+**Note** 
+
+- Most of the variables in demo.tfvars are marked as `false`, as they are not part of required initial policies. This can be made `true` based on need.
+
+- Some of the baseline scripts may not have the `demo.tfvars`, you may execute only with default varialble file.
+
 ### Input variable files
 
 Input variable files allow for the user to configure configuration definitions for multiple environments in different files.

--- a/baselines/getting_started/aws/aws_check_cost_controls/variables.tf
+++ b/baselines/getting_started/aws/aws_check_cost_controls/variables.tf
@@ -242,7 +242,6 @@ variable "enable_workspace_schedule_tag_policies" {
 
 variable "turbot_profile" {
   description = "Enter profile matching your turbot cli credentials."
-  default     = "default"
 }
 
 variable "smart_folder_name" {

--- a/baselines/getting_started/aws/aws_check_encryption/README.md
+++ b/baselines/getting_started/aws/aws_check_encryption/README.md
@@ -52,6 +52,12 @@ terraform init
 terraform apply --var-file demo.tfvars
 ```
 
+**Note** 
+
+- Most of the variables in demo.tfvars are marked as `false`, as they are not part of required initial policies. This can be made `true` based on need.
+
+- Some of the baseline scripts may not have the `demo.tfvars`, you may execute only with default varialble file.
+
 ### Input variable files
 
 Input variable files allow for the user to configure configuration definitions for multiple environments in different files.

--- a/baselines/getting_started/aws/aws_check_encryption/variables.tf
+++ b/baselines/getting_started/aws/aws_check_encryption/variables.tf
@@ -96,7 +96,6 @@ variable "enable_elasticsearch_domain_encryption_policies" {
 
 variable "turbot_profile" {
   description = "Enter profile matching your turbot cli credentials."
-  default     = "default"
 }
 
 variable "smart_folder_name" {

--- a/baselines/getting_started/aws/aws_check_public_access/README.md
+++ b/baselines/getting_started/aws/aws_check_public_access/README.md
@@ -51,6 +51,12 @@ terraform init
 terraform apply --var-file demo.tfvars
 ```
 
+**Note** 
+
+- Most of the variables in demo.tfvars are marked as `false`, as they are not part of required initial policies. This can be made `true` based on need.
+
+- Some of the baseline scripts may not have the `demo.tfvars`, you may execute only with default varialble file.
+
 ### Input variable files
 
 Input variable files allow for the user to configure configuration definitions for multiple environments in different files.

--- a/baselines/getting_started/aws/aws_check_public_access/variable.tf
+++ b/baselines/getting_started/aws/aws_check_public_access/variable.tf
@@ -62,7 +62,6 @@ variable "enable_aws_trusted_accounts_template" {
 
 variable "turbot_profile" {
   description = "Enter profile matching your turbot cli credentials."
-  default     = "default"
 }
 
 variable "smart_folder_name" {

--- a/baselines/getting_started/aws/aws_check_regions/README.md
+++ b/baselines/getting_started/aws/aws_check_regions/README.md
@@ -66,6 +66,12 @@ terraform init
 terraform apply --var-file demo.tfvars
 ```
 
+**Note** 
+
+- Most of the variables in demo.tfvars are marked as `false`, as they are not part of required initial policies. This can be made `true` based on need.
+
+- Some of the baseline scripts may not have the `demo.tfvars`, you may execute only with default varialble file.
+
 ### Input variable files
 
 Input variable files allow for the user to configure configuration definitions for multiple environments in different files.

--- a/baselines/getting_started/aws/aws_check_regions/variables.tf
+++ b/baselines/getting_started/aws/aws_check_regions/variables.tf
@@ -203,7 +203,6 @@ variable "resource_approved_regions_region_list" {
 
 variable "turbot_profile" {
   description = "Enter profile matching your turbot cli credentials."
-  default     = "default"
 }
 
 variable "smart_folder_name" {

--- a/baselines/getting_started/aws/aws_check_stack/aws_account_iam_stack_policies.tf
+++ b/baselines/getting_started/aws/aws_check_stack/aws_account_iam_stack_policies.tf
@@ -1,6 +1,7 @@
 # AWS > Account > Stack
 # https://turbot.com/v5/mods/turbot/aws/inspect#/policy/types/accountStack
 resource "turbot_policy_setting" "aws_account_iam_stack" {
+  count    = var.aws_account_iam_stack ? 1 : 0
   resource = turbot_smart_folder.aws_stack.id
   type     = "tmod:@turbot/aws#/policy/types/accountStack"
   value    = "Check: Configured"
@@ -10,6 +11,7 @@ resource "turbot_policy_setting" "aws_account_iam_stack" {
 # AWS > Account > Stack > Terraform Version
 # https://turbot.com/v5/mods/turbot/aws/inspect#/policy/types/accountStackTerraformVersion
 resource "turbot_policy_setting" "aws_account_iam_stack_tfversion" {
+  count    = var.aws_account_iam_stack_tfversion ? 1 : 0
   resource = turbot_smart_folder.aws_stack.id
   type     = "tmod:@turbot/aws#/policy/types/accountStackTerraformVersion"
   value    = "0.13.*"
@@ -18,6 +20,7 @@ resource "turbot_policy_setting" "aws_account_iam_stack_tfversion" {
 # AWS > Account > Stack > Source
 # https://turbot.com/v5/mods/turbot/aws/inspect#/policy/types/accountStackSource
 resource "turbot_policy_setting" "aws_account_iam_stack_source" {
+  count    = var.aws_account_iam_stack_source ? 1 : 0
   resource = turbot_smart_folder.aws_stack.id
   type     = "tmod:@turbot/aws#/policy/types/accountStackSource"
   value    = <<-SOURCE
@@ -28,6 +31,7 @@ resource "turbot_policy_setting" "aws_account_iam_stack_source" {
 # AWS > Turbot > Permissions > Custom Levels [Account]
 # https://turbot.com/v5/mods/turbot/aws-iam/inspect#/policy/types/permissionsCustomLevelsAccount
 resource "turbot_policy_setting" "aws_iam_permissions_custom_levels_account" {
+  count    = var.aws_iam_permissions_custom_levels_account ? 1 : 0
   resource = turbot_smart_folder.aws_stack.id
   type     = "tmod:@turbot/aws-iam#/policy/types/permissionsCustomLevelsAccount"
   value    = <<EOT

--- a/baselines/getting_started/aws/aws_check_stack/outputs.tf
+++ b/baselines/getting_started/aws/aws_check_stack/outputs.tf
@@ -1,3 +1,19 @@
+output "aws_account_iam_stack" {
+  value = var.aws_account_iam_stack
+}
+
+output "aws_account_iam_stack_tfversion" {
+  value = var.aws_account_iam_stack_tfversion
+}
+
+output "aws_account_iam_stack_source" {
+  value = var.aws_account_iam_stack_source
+}
+
+output "aws_iam_permissions_custom_levels_account" {
+  value = var.aws_iam_permissions_custom_levels_account
+}
+
 output "turbot_profile" {
   value = var.turbot_profile
 }

--- a/baselines/getting_started/aws/aws_check_stack/variables.tf
+++ b/baselines/getting_started/aws/aws_check_stack/variables.tf
@@ -1,3 +1,31 @@
+# Baseline Configuration
+
+variable "aws_account_iam_stack" {
+  type        = bool
+  description = "AWS IAM stack policies for baseline"
+  default     = true
+}
+
+variable "aws_account_iam_stack_tfversion" {
+  type        = bool
+  description = "AWS account IAM stack policies for baseline"
+  default     = true
+}
+
+variable "aws_account_iam_stack_source" {
+  type        = bool
+  description = "AWS account IAM stack source policies for baseline"
+  default     = true
+}
+
+variable "aws_iam_permissions_custom_levels_account" {
+  type        = bool
+  description = "AWS IAM permissions customer levels accounts policies for baseline"
+  default     = true
+}
+
+# Smartfolder Configuration
+
 variable "turbot_profile" {
   description = "Enter profile matching your turbot cli credentials."
 }


### PR DESCRIPTION
Closes #441