### PR TITLE
Baseline - Clean GCP baseline TF files to remove default and readme updates #443

### DIFF
--- a/baselines/getting_started/gcp/gcp_baseline/README.md
+++ b/baselines/getting_started/gcp/gcp_baseline/README.md
@@ -66,6 +66,7 @@ terraform apply --var-file demo.tfvars
 ```
 
 **Note** 
+
 - Most of the variables in demo.tfvars are marked as `false`, as they are not part of required initial policies. This can be made `true` based on need.
 
 - Some of the baseline scripts may not have the `demo.tfvars`, you may execute only with default varialble file.

--- a/baselines/getting_started/gcp/gcp_baseline/variables.tf
+++ b/baselines/getting_started/gcp/gcp_baseline/variables.tf
@@ -15,7 +15,6 @@ variable "use_event_polling" {
 
 variable "turbot_profile" {
   description = "Enter profile matching your turbot cli credentials."
-  default     = "default"
 }
 
 variable "smart_folder_name" {


### PR DESCRIPTION
Closes #443