### PR TITLE
Add policy pack: Enforce AWS EC2 Snapshots Active - Check if AMI Attached

### DIFF
--- a/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/README.md
+++ b/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/README.md
@@ -1,0 +1,81 @@
+---
+categories: ["cost controls", "storage", "security"]
+primary_category: "cost controls"
+type: "policy_pack"
+---
+
+# Enforce AWS EC2 Snapshots Active - Check if AMI Attached
+
+This policy pack enforces that AWS EC2 snapshots are active, using a multi-query calculated policy. If a snapshot is referenced by any AMI (Amazon Machine Image), the policy is set to CHECK for safety; otherwise, it enforces deletion.
+
+## Features
+- Multi-query calculated policy for `AWS > EC2 > Snapshot > Active`:
+  - If a snapshot is referenced by any AMI (via `BlockDeviceMappings[].Ebs.SnapshotId`), the policy returns `"Check: Active"` (snapshot is in use and not deleted).
+  - If no AMIs reference the snapshot, the policy returns `"Enforce: Delete inactive with 30 days warning"` (safe to delete).
+- Ensures only snapshots not in use by any AMI are targeted for cleanup.
+- All logic is implemented as a calculated policy, visible in the Guardrails UI as part of the policy pack.
+
+> **NOTE:**
+> The `Enforce` action and warning period (currently set to 30 days) can be easily adjusted in the policy logic to meet your organization's requirements. Simply update the policy value in the calculated policy template as needed.
+
+## Requirements
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-ec2](https://hub.guardrails.turbot.com/mods/aws/mods/aws-ec2)
+
+## Usage
+
+### Install Policy Pack
+
+Clone:
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached
+```
+
+Run the Terraform to create the policy pack in your workspace:
+```sh
+terraform init
+terraform plan
+```
+Then apply the changes:
+```sh
+terraform apply
+```
+
+### Attaching the Policy Pack
+
+By default, the policy pack is not attached to any resource. To test or use it:
+- Add a `turbot_policy_pack_attachment` resource in `main.tf` for your target resource (e.g., AWS account).
+- Apply the changes with Terraform.
+- You can also attach the policy pack manually in the Guardrails UI for production.
+
+### How the Policy Works
+- The calculated policy uses two queries:
+  1. Gets the current snapshot's ID.
+  2. Searches for any AMIs referencing this snapshot ID in their `BlockDeviceMappings[].Ebs.SnapshotId`.
+- If any AMIs reference the snapshot, it is considered active and not deleted (set to CHECK for safety).
+- If no AMIs reference the snapshot, it is considered inactive and will be deleted with a 30-day warning.
+
+By default, the calculated policy enforces deletion only when the snapshot is not in use. You can adjust the warning period in the policy logic if needed.
+
+## Testing the Policy Pack Attachment
+
+To test this policy pack on a specific resource (such as an AWS account, folder, or other supported resource), you can use the following Terraform block in your `main.tf`:
+
+```hcl
+# Uncomment and update the resource ID below to attach the policy pack for testing.
+# This is useful for knowledge building, validation, or development.
+# For production, it is recommended to attach the policy pack manually in the Guardrails UI.
+#
+# resource "turbot_policy_pack_attachment" "test" {
+#   policy_pack = turbot_policy_pack.main.id
+#   resource    = "<your_resource_id_here>"
+# }
+```
+
+- Replace `<your_resource_id_here>` with the ID of the resource you want to test against.
+- After testing, you can comment out or remove this block for production readiness.
+
+## Support
+For more information, see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs) and [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication).

--- a/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/main.tf
+++ b/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/main.tf
@@ -1,0 +1,13 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce AWS EC2 Snapshots Active - Check if AMI Attached"
+  description = "Enforce that AWS EC2 snapshots are active, but set to CHECK if the snapshot is attached to an AMI for safety."
+  akas        = ["aws_ec2_enforce_snapshots_active_check_if_ami_attached"]
+}
+
+# Uncomment the block below to attach the policy pack to a specific resource for testing or knowledge building.
+# For production, it is recommended to attach the policy pack manually in the Guardrails UI.
+#
+# resource "turbot_policy_pack_attachment" "test" {
+#   policy_pack = turbot_policy_pack.main.id
+#   resource    = "289217437897594"
+# }

--- a/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/policies.tf
+++ b/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/policies.tf
@@ -1,0 +1,72 @@
+# AWS > EC2 > Snapshot > Active (Multi-query Calculated Policy)
+#
+# Logic:
+# - The first query gets the SnapshotId of the current snapshot resource.
+# - The second query searches for any AMI (Amazon Machine Image) resources
+#   where any BlockDeviceMappings[].Ebs.SnapshotId matches this snapshot's ID.
+#   (This is found in the AMI's data block, e.g.:
+#     BlockDeviceMappings:
+#       - DeviceName: /dev/xvda
+#         Ebs:
+#           SnapshotId: snap-03f6d591f26abd4f4
+#           ...)
+# - If any AMIs reference this snapshot, the policy returns 'Check: Active'
+#   (meaning the snapshot is still in use and should not be deleted).
+# - If no AMIs reference this snapshot, the policy returns
+#   'Enforce: Delete inactive with 30 days warning' (safe to clean up).
+#
+# This logic ensures that only snapshots not in use by any AMI are targeted for deletion.
+resource "turbot_policy_setting" "aws_ec2_snapshot_active" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/aws-ec2#/policy/types/snapshotActive"
+  template_input = <<-EOT
+    - |
+      {
+        resource {
+          snapshot_id: get(path: "SnapshotId")
+        }
+      }
+    - |
+      {
+        resource {
+          data
+          snapshot_id: get(path: "SnapshotId")
+        }
+        images: resources(filter: "resourceType:'tmod:@turbot/aws-ec2#/resource/types/ami' $.BlockDeviceMappings.*.Ebs.SnapshotId:{{$.resource.snapshot_id}} limit:5000") {
+          metadata {
+            stats {
+              total
+            }
+          }
+        }
+      }
+    EOT
+  template       = <<-EOT
+    {%- if $.images.metadata.stats.total > 0 -%}
+      "Check: Active"
+    {%- else -%}
+      "Enforce: Delete inactive with 30 days warning"
+    {%- endif -%}
+  EOT
+}
+
+# AWS > EC2 > Snapshot > Active > Age
+resource "turbot_policy_setting" "aws_ec2_snapshot_active_age" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-ec2#/policy/types/snapshotActiveAge"
+  value    = "Force inactive if age > 30 days"
+}
+
+# AWS > EC2 > Snapshot > Active > Budget
+resource "turbot_policy_setting" "aws_ec2_snapshot_active_budget" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-ec2#/policy/types/snapshotActiveBudget"
+  value    = "Skip"
+}
+
+# AWS > EC2 > Snapshot > Active > Last Modified
+resource "turbot_policy_setting" "aws_ec2_snapshot_active_last_modified" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-ec2#/policy/types/snapshotActiveLastModified"
+  value    = "Skip"
+}

--- a/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/providers.tf
+++ b/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {}

--- a/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/variables.tf
+++ b/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/variables.tf
@@ -1,0 +1,5 @@
+variable "test_resource_id" {
+  description = "The resource ID to attach the policy pack to for testing."
+  type        = string
+  default     = "357744930395742"
+}


### PR DESCRIPTION

This commit introduces a new policy pack that enforces AWS EC2 snapshots to be active, checking if they are attached to any AMI. The policy utilizes a multi-query calculated approach to determine if snapshots can be safely deleted or should remain active. Additionally, it includes a README for usage instructions and testing guidance.