### PR TITLE
Fix links to `turbot/github`

### DIFF
--- a/policy_packs/github/enforce_base_permissions_is_set_to_read_for_organizations/README.md
+++ b/policy_packs/github/enforce_base_permissions_is_set_to_read_for_organizations/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_default_branch_name_for_repositories/README.md
+++ b/policy_packs/github/enforce_default_branch_name_for_repositories/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_delete_branch_on_merge_is_enabled_for_repositories/README.md
+++ b/policy_packs/github/enforce_delete_branch_on_merge_is_enabled_for_repositories/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_dependabot_alerts_are_enabled_for_repositories/README.md
+++ b/policy_packs/github/enforce_dependabot_alerts_are_enabled_for_repositories/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_dependabot_security_updates_are_enabled_for_repositories/README.md
+++ b/policy_packs/github/enforce_dependabot_security_updates_are_enabled_for_repositories/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_deploy_keys_are_disabled_for_organizations/README.md
+++ b/policy_packs/github/enforce_deploy_keys_are_disabled_for_organizations/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_forking_of_private_repositories_is_disabled_for_organizations/README.md
+++ b/policy_packs/github/enforce_forking_of_private_repositories_is_disabled_for_organizations/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_pages_creation_is_disabled_for_organizations/README.md
+++ b/policy_packs/github/enforce_pages_creation_is_disabled_for_organizations/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_pull_request_merge_configuration_settings_are_enabled_for_repositories/README.md
+++ b/policy_packs/github/enforce_pull_request_merge_configuration_settings_are_enabled_for_repositories/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_repository_creation_is_disabled_for_organizations/README.md
+++ b/policy_packs/github/enforce_repository_creation_is_disabled_for_organizations/README.md
@@ -21,7 +21,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 

--- a/policy_packs/github/enforce_unwanted_users_are_blocked_from_organizations/README.md
+++ b/policy_packs/github/enforce_unwanted_users_are_blocked_from_organizations/README.md
@@ -22,7 +22,7 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 
 - [Terraform](https://developer.hashicorp.com/terraform/install)
 - Guardrails mods:
-  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github)
+  - [@turbot/github](https://hub.guardrails.turbot.com/mods/github/mods/github)
 
 ### Credentials
 


### PR DESCRIPTION
The link:
https://hub.guardrails.turbot.com/mods/github

does not work.
