### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,3 +302,6 @@ $RECYCLE.BIN/
 
 # debuggers
 .vscode
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to prevent Claude Code local settings from being committed

## Test plan
- [ ] Verify `.claude/` directory is no longer shown in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)