### PR TITLE
Add Python example: get resource CMDB data by AKA

### DIFF
--- a/api_examples/python/get-resource-cmdb/.config.example
+++ b/api_examples/python/get-resource-cmdb/.config.example
@@ -1,0 +1,46 @@
+# Guardrails CMDB Lookup Configuration
+#
+# Defines the workspaces to search when looking up resources.
+# Workspaces are searched in order; the search stops at the first match.
+#
+# Auth types:
+#   profile  - Use a named profile from ~/.config/turbot/credentials.yml
+#   keys     - Inline access key and secret key
+#   env      - Read from environment variables (configurable per workspace)
+#
+# Providers: aws, azure, gcp, oci
+#   Used to skip workspaces that can't contain the requested resource.
+#   For example, an ARN lookup skips workspaces that don't include "aws".
+
+workspaces:
+  - name: aws-prod
+    url: "https://aws-prod.cloud.turbot.com"
+    auth: profile
+    profile: aws-prod
+    providers:
+      - aws
+
+  - name: aws-staging
+    url: "https://aws-staging.cloud.turbot.com"
+    auth: keys
+    access_key: "your-access-key-here"
+    secret_key: "your-secret-key-here"
+    providers:
+      - aws
+
+  - name: azure-prod
+    url: "https://azure-prod.cloud.turbot.com"
+    auth: env
+    access_key_var: AZURE_PROD_TURBOT_ACCESS_KEY  # defaults to TURBOT_ACCESS_KEY_ID if omitted
+    secret_key_var: AZURE_PROD_TURBOT_SECRET_KEY  # defaults to TURBOT_SECRET_ACCESS_KEY if omitted
+    providers:
+      - azure
+
+  - name: multi-cloud
+    url: "https://multi.cloud.turbot.com"
+    auth: profile
+    profile: multi
+    providers:
+      - aws
+      - azure
+      - gcp

--- a/api_examples/python/get-resource-cmdb/.gitignore
+++ b/api_examples/python/get-resource-cmdb/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+.config

--- a/api_examples/python/get-resource-cmdb/README.md
+++ b/api_examples/python/get-resource-cmdb/README.md
@@ -1,0 +1,150 @@
+# Get Resource CMDB Data
+
+Looks up a resource in Guardrails and returns the CMDB data. Supports two lookup modes and searches across multiple workspaces, stopping at the first match.
+
+Useful for integrations (e.g. SolarWinds, ServiceNow) that need to pull resource configuration data from the Guardrails CMDB via the GraphQL API.
+
+## Prerequisites
+
+- [Python 3.\*.\*](https://www.python.org/downloads/)
+- [Pip](https://pip.pypa.io/en/stable/installing/)
+
+## Setup
+
+### Virtual environment
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Configuration
+
+Copy the example config and edit it with your workspace details:
+
+```shell
+cp .config.example .config
+```
+
+The `.config` file defines which workspaces to search and how to authenticate to each one:
+
+```yaml
+workspaces:
+  - name: aws-prod
+    url: "https://aws-prod.cloud.turbot.com"
+    auth: profile              # use Turbot CLI credentials (~/.config/turbot/credentials.yml)
+    profile: aws-prod          # Turbot CLI profile name
+    providers:
+      - aws
+
+  - name: azure-prod
+    url: "https://azure-prod.cloud.turbot.com"
+    auth: keys                 # inline credentials
+    access_key: "your-access-key-here"
+    secret_key: "your-secret-key-here"
+    providers:
+      - azure
+
+  - name: multi-cloud
+    url: "https://multi.cloud.turbot.com"
+    auth: env                  # read from env vars
+    access_key_var: MULTI_TURBOT_AK  # custom env var names (optional)
+    secret_key_var: MULTI_TURBOT_SK
+    providers:
+      - aws
+      - azure
+      - gcp
+```
+
+**Auth types:**
+
+| Type | Description |
+| ---- | ----------- |
+| `profile` | Uses a named profile from the [Turbot Guardrails CLI](https://turbot.com/guardrails/docs/reference/cli) credentials file (`~/.config/turbot/credentials.yml`). Set `profile` to the Turbot CLI profile name. **Note:** This refers to Turbot Guardrails CLI profiles, not AWS CLI profiles. See the [Turbot CLI installation and configuration guide](https://turbot.com/guardrails/docs/reference/cli/installation) for setup instructions. |
+| `keys` | Inline Guardrails API access key and secret key. Set `access_key` and `secret_key` directly in the config. API keys can be generated from the Guardrails console under **Permissions > API Keys**. See [API access keys documentation](https://turbot.com/guardrails/docs/guides/iam/access-keys). |
+| `env` | Reads credentials from environment variables. Defaults to `TURBOT_ACCESS_KEY_ID` and `TURBOT_SECRET_ACCESS_KEY`. Set `access_key_var` and `secret_key_var` to use custom variable names per workspace (useful with key vaults). |
+
+**Providers:** `aws`, `azure`, `gcp`, `oci`. Used to skip workspaces that can't contain the requested resource. For example, an ARN lookup automatically skips workspaces that don't include `aws`.
+
+## Usage
+
+```shell
+python3 get_resource_cmdb.py [OPTIONS]
+```
+
+### Lookup modes
+
+| Mode | Description |
+| ---- | ----------- |
+| `--aka` | Direct lookup by AKA (e.g. ARN, Azure resource ID). Fast, single API call per workspace. |
+| `--resource-id` + `--resource-type` | Filter-based lookup by cloud resource ID and Guardrails resource type URI. Use when you have the cloud ID but not the full AKA. |
+
+The two modes are mutually exclusive.
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-a`, `--aka` | The AKA of the resource (e.g. AWS ARN, Azure resource ID). |
+| `-r`, `--resource-id` | The cloud resource ID (e.g. `i-0abcd1234efgh5678`). Requires `--resource-type`. |
+| `-t`, `--resource-type` | The Guardrails resource type URI (e.g. `tmod:@turbot/aws-ec2#/resource/types/instance`). |
+| `-w`, `--workspace` | Search only this workspace (by name from config). |
+| `-c`, `--config-file` | Path to config file. Default: `.config` in the script directory. |
+| `--json-output` | Output raw JSON instead of formatted text. |
+
+### Examples
+
+#### Look up by ARN
+
+```shell
+python3 get_resource_cmdb.py \
+  --aka "arn:aws:ec2:us-east-1:123456789012:instance/i-0abcd1234efgh5678"
+```
+
+#### Look up by resource ID and type
+
+```shell
+python3 get_resource_cmdb.py \
+  --resource-id "i-0abcd1234efgh5678" \
+  --resource-type "tmod:@turbot/aws-ec2#/resource/types/instance"
+```
+
+#### Search a specific workspace
+
+```shell
+python3 get_resource_cmdb.py \
+  --workspace aws-prod \
+  --aka "arn:aws:ec2:us-east-1:123456789012:instance/i-0abcd1234efgh5678"
+```
+
+#### Look up an Azure VM
+
+```shell
+python3 get_resource_cmdb.py \
+  --aka "azure:///subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/my-vm"
+```
+
+#### Output raw JSON
+
+```shell
+python3 get_resource_cmdb.py \
+  --aka "arn:aws:s3:::my-bucket" \
+  --json-output
+```
+
+## Finding resource type URIs
+
+Browse resource types and their AKA formats at [hub.guardrails.turbot.com](https://hub.guardrails.turbot.com). Each resource type page shows the URI to use with `--resource-type`.
+
+Common examples:
+
+| Resource | URI |
+| -------- | --- |
+| AWS EC2 Instance | `tmod:@turbot/aws-ec2#/resource/types/instance` |
+| AWS S3 Bucket | `tmod:@turbot/aws-s3#/resource/types/bucket` |
+| AWS IAM Role | `tmod:@turbot/aws-iam#/resource/types/role` |
+| AWS Lambda Function | `tmod:@turbot/aws-lambda#/resource/types/function` |
+| Azure Virtual Machine | `tmod:@turbot/azure-compute#/resource/types/virtualMachine` |
+| Azure Storage Account | `tmod:@turbot/azure-storage#/resource/types/storageAccount` |
+| GCP Compute Instance | `tmod:@turbot/gcp-computeengine#/resource/types/instance` |

--- a/api_examples/python/get-resource-cmdb/get_resource_cmdb.py
+++ b/api_examples/python/get-resource-cmdb/get_resource_cmdb.py
@@ -1,0 +1,384 @@
+import os
+import click
+import requests
+import json
+import sys
+import yaml
+from base64 import b64encode
+from xdg import XDG_CONFIG_HOME
+
+
+GRAPHQL_PATH = 'api/latest/graphql'
+_json_mode = False
+
+
+def log(msg):
+    """Print status messages to stderr in JSON mode, stdout otherwise."""
+    if _json_mode:
+        print(msg, file=sys.stderr)
+    else:
+        print(msg)
+
+PROVIDER_PREFIXES = {
+    'aws': ['arn:aws:'],
+    'azure': ['azure:///'],
+    'gcp': ['//compute.googleapis.com/', '//storage.googleapis.com/', '//container.googleapis.com/'],
+    'oci': ['ocid1.'],
+}
+
+RESOURCE_BY_AKA_QUERY = '''
+  query GetResource($id: ID!) {
+    resource(id: $id) {
+      turbot {
+        id
+        title
+        akas
+        createTimestamp
+        updateTimestamp
+        resourceTypeId
+        parentId
+        path
+        tags
+      }
+      type {
+        title
+        uri
+      }
+      data
+    }
+  }
+'''
+
+RESOURCE_BY_FILTER_QUERY = '''
+  query FindResource($filter: [String!]!) {
+    resources(filter: $filter) {
+      items {
+        turbot {
+          id
+          title
+          akas
+          createTimestamp
+          updateTimestamp
+          resourceTypeId
+          parentId
+          path
+          tags
+        }
+        type {
+          title
+          uri
+        }
+        data
+      }
+    }
+  }
+'''
+
+VALIDATE_RESOURCE_TYPE_QUERY = '''
+  query ValidateResourceType($id: ID!) {
+    resourceType(id: $id) {
+      title
+      uri
+    }
+  }
+'''
+
+
+def load_config(config_path=None):
+    """Load the workspace configuration file."""
+    if config_path is None:
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.config')
+
+    if not os.path.exists(config_path):
+        print("Config file not found: {}".format(config_path))
+        print("Copy .config.example to .config and edit it with your workspace details.")
+        sys.exit(1)
+
+    with open(config_path, 'r') as f:
+        config = yaml.safe_load(f)
+
+    if not config or 'workspaces' not in config:
+        print("Invalid config file: missing 'workspaces' key.")
+        sys.exit(1)
+
+    return config['workspaces']
+
+
+def detect_provider(identifier):
+    """Detect the cloud provider from an AKA or resource type URI."""
+    for provider, prefixes in PROVIDER_PREFIXES.items():
+        for prefix in prefixes:
+            if identifier.startswith(prefix):
+                return provider
+    # Check resource type URIs like tmod:@turbot/aws-ec2#...
+    if 'aws' in identifier.lower().split('#')[0]:
+        return 'aws'
+    if 'azure' in identifier.lower().split('#')[0]:
+        return 'azure'
+    if 'gcp' in identifier.lower().split('#')[0]:
+        return 'gcp'
+    if 'oci' in identifier.lower().split('#')[0]:
+        return 'oci'
+    return None
+
+
+def create_session(workspace):
+    """Create an authenticated requests.Session for a workspace.
+
+    Returns (endpoint, session) where session has auth headers pre-configured.
+    Credentials are encapsulated in the session and not exposed to callers.
+    """
+    auth = workspace.get('auth', 'profile')
+    url = workspace['url'].rstrip('/')
+
+    if auth == 'profile':
+        profile_name = workspace.get('profile', 'default')
+        turbot_config = "{}/turbot/credentials.yml".format(XDG_CONFIG_HOME)
+        if not os.path.exists(turbot_config):
+            raise ValueError("Credentials file not found: {}".format(turbot_config))
+        with open(turbot_config, 'r') as f:
+            creds = yaml.safe_load(f)
+        if profile_name not in creds:
+            raise ValueError("Profile '{}' not found in credentials file".format(profile_name))
+        access_key = creds[profile_name]['accessKey']
+        secret_key = creds[profile_name]['secretKey']
+
+    elif auth == 'keys':
+        access_key = workspace.get('access_key')
+        secret_key = workspace.get('secret_key')
+        if not access_key or not secret_key:
+            raise ValueError("Workspace '{}' uses auth:keys but missing access_key or secret_key".format(
+                workspace['name']))
+
+    elif auth == 'env':
+        ak_var = workspace.get('access_key_var', 'TURBOT_ACCESS_KEY_ID')
+        sk_var = workspace.get('secret_key_var', 'TURBOT_SECRET_ACCESS_KEY')
+        access_key = os.getenv(ak_var)
+        secret_key = os.getenv(sk_var)
+        if not access_key or not secret_key:
+            raise ValueError("Auth type 'env' requires {} and {} environment variables".format(ak_var, sk_var))
+
+    else:
+        raise ValueError("Unknown auth type: {}".format(auth))
+
+    endpoint = "{}/{}".format(url, GRAPHQL_PATH)
+    auth_bytes = '{}:{}'.format(access_key, secret_key).encode("utf-8")
+    token = b64encode(auth_bytes).decode()
+
+    session = requests.Session()
+    session.headers.update({'Authorization': 'Basic {}'.format(token)})
+
+    # Clear credential variables
+    del access_key, secret_key, token  # noqa: F821
+
+    return endpoint, session
+
+
+def run_graphql(endpoint, session, query, variables):
+    """Execute a GraphQL query using an authenticated session."""
+    response = session.post(
+        endpoint,
+        json={'query': query, 'variables': variables}
+    )
+    if response.status_code != 200:
+        raise Exception("HTTP {}".format(response.status_code))
+    return response.json()
+
+
+def validate_resource_type(endpoint, session, resource_type):
+    """Validate that a resource type URI exists in the workspace. Returns the type title or None."""
+    result = run_graphql(endpoint, session, VALIDATE_RESOURCE_TYPE_QUERY, {'id': resource_type})
+    if "errors" in result:
+        return None
+    rt = result.get('data', {}).get('resourceType')
+    if rt:
+        return rt.get('title')
+    return None
+
+
+def query_by_aka(endpoint, session, aka):
+    """Look up a resource by AKA. Returns the resource dict or None."""
+    result = run_graphql(endpoint, session, RESOURCE_BY_AKA_QUERY, {'id': aka})
+    if "errors" in result:
+        return None
+    return result['data']['resource']
+
+
+def query_by_filter(endpoint, session, resource_id, resource_type):
+    """Look up a resource by resource ID and type using a filter query. Returns the resource dict or None."""
+    filter_str = "resourceTypeId:'{}' {} limit:1".format(resource_type, resource_id)
+    result = run_graphql(endpoint, session, RESOURCE_BY_FILTER_QUERY, {'filter': filter_str})
+    if "errors" in result:
+        return None
+    items = result['data']['resources']['items']
+    if items:
+        return items[0]
+    return None
+
+
+def format_resource(resource, ws_name, ws_url):
+    """Format a resource for display. Returns a string."""
+    lines = []
+    lines.append("--- Resource Summary ---")
+    lines.append("Workspace:     {} ({})".format(ws_name, ws_url))
+    lines.append("Turbot ID:     {}".format(resource['turbot']['id']))
+    lines.append("Title:         {}".format(resource['turbot']['title']))
+    lines.append("Type:          {} ({})".format(resource['type']['title'], resource['type']['uri']))
+    lines.append("Created:       {}".format(resource['turbot']['createTimestamp']))
+    lines.append("Updated:       {}".format(resource['turbot']['updateTimestamp']))
+    lines.append("AKAs:          {}".format(', '.join(resource['turbot']['akas'])))
+
+    if resource['turbot'].get('tags'):
+        lines.append("\n--- Tags ---")
+        for key, value in resource['turbot']['tags'].items():
+            lines.append("  {}: {}".format(key, value))
+
+    lines.append("\n--- CMDB Data ---")
+    lines.append(json.dumps(resource['data'], indent=2))
+    return '\n'.join(lines)
+
+
+def format_json(resource, ws_name, ws_url):
+    """Format a resource as JSON. Returns a string."""
+    output = {
+        '_workspace': ws_name,
+        '_url': ws_url,
+        'turbot': resource['turbot'],
+        'type': resource['type'],
+        'data': resource['data'],
+    }
+    return json.dumps(output, indent=2)
+
+
+@click.command()
+@click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="Path to workspace config file. Default: .config")
+@click.option('-w', '--workspace', help="Search only this workspace (by name from config).")
+@click.option('-a', '--aka', help="The AKA (e.g. ARN) of the resource to look up.")
+@click.option('-r', '--resource-id', help="The cloud resource ID (e.g. i-01dcb5c09e8f46d28). Requires --resource-type.")
+@click.option('-t', '--resource-type', help="The Guardrails resource type URI (e.g. tmod:@turbot/aws-ec2#/resource/types/instance).")
+@click.option('--json-output', is_flag=True, help="Output raw JSON instead of formatted text.")
+def get_resource_cmdb(config_file, workspace, aka, resource_id, resource_type, json_output):
+    """Look up a Guardrails CMDB resource by AKA or by resource ID + type.
+
+    \b
+    Two lookup modes:
+      --aka                     Direct lookup by AKA (e.g. ARN). Fast, single API call.
+      --resource-id + --resource-type  Filter-based lookup by cloud resource ID and type.
+
+    \b
+    Examples:
+      python3 get_resource_cmdb.py --aka "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123"
+      python3 get_resource_cmdb.py --resource-id i-abc123 --resource-type tmod:@turbot/aws-ec2#/resource/types/instance
+    """
+
+    global _json_mode
+    _json_mode = json_output
+
+    # Validate options
+    if aka and (resource_id or resource_type):
+        log("Error: --aka and --resource-id/--resource-type are mutually exclusive.")
+        sys.exit(1)
+
+    if not aka and not resource_id:
+        log("Error: Provide either --aka or --resource-id with --resource-type.")
+        sys.exit(1)
+
+    if resource_id and not resource_type:
+        log("Error: --resource-id requires --resource-type.")
+        log("Browse resource types at: https://hub.guardrails.turbot.com")
+        sys.exit(1)
+
+    if resource_type and not resource_id:
+        log("Error: --resource-type requires --resource-id.")
+        sys.exit(1)
+
+    use_filter = bool(resource_id)
+
+    workspaces = load_config(config_file)
+
+    # Filter to a single workspace if --workspace is specified
+    if workspace:
+        matches = [w for w in workspaces if w['name'] == workspace]
+        if not matches:
+            available = ', '.join(w['name'] for w in workspaces)
+            log("Workspace '{}' not found in config. Available: {}".format(workspace, available))
+            sys.exit(1)
+        workspaces = matches
+
+    # Detect provider and filter workspaces
+    identifier = aka or resource_type
+    provider = detect_provider(identifier)
+    if provider and not workspace:
+        original_count = len(workspaces)
+        workspaces = [w for w in workspaces if provider in w.get('providers', [])]
+        if not workspaces:
+            log("No workspaces configured for provider '{}'. Check your .config file.".format(provider))
+            sys.exit(1)
+        skipped = original_count - len(workspaces)
+        if skipped > 0:
+            log("Detected {} resource, skipping {} non-{} workspace(s).".format(
+                provider.upper(), skipped, provider))
+
+    # Search workspaces in order
+    for ws in workspaces:
+        name = ws['name']
+
+        try:
+            endpoint, session = create_session(ws)
+        except ValueError as e:
+            log("[{}] Skipping: {}".format(name, e))
+            continue
+
+        log("[{}] Searching {}...".format(name, ws['url']))
+
+        # Validate resource type if using filter mode
+        if use_filter:
+            type_title = validate_resource_type(endpoint, session, resource_type)
+            if type_title is None:
+                log("[{}] Resource type '{}' not found. It may not be installed in this workspace.".format(
+                    name, resource_type))
+                log("    Browse available types at: https://hub.guardrails.turbot.com")
+                continue
+
+        try:
+            if use_filter:
+                resource = query_by_filter(endpoint, session, resource_id, resource_type)
+            else:
+                resource = query_by_aka(endpoint, session, aka)
+        except Exception as e:
+            log("[{}] Error: {}".format(name, e))
+            continue
+
+        if resource:
+            if not json_output:
+                log("[{}] Found!\n".format(name))
+            print(format_json(resource, name, ws['url']) if json_output
+                  else format_resource(resource, name, ws['url']))
+            return
+
+    # Not found in any workspace
+    if json_output:
+        err = {"error": "not_found"}
+        if aka:
+            err["aka"] = aka
+        else:
+            err["resource_id"] = resource_id
+            err["resource_type"] = resource_type
+        print(json.dumps(err, indent=2))
+    else:
+        if aka:
+            log("\nNo resource found matching AKA: {}".format(aka))
+        else:
+            log("\nNo resource found matching ID '{}' with type '{}'.".format(resource_id, resource_type))
+        log("Searched {} workspace(s).".format(len(workspaces)))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    if (sys.version_info > (3, 4)):
+        try:
+            get_resource_cmdb()
+        except Exception as e:
+            print(e)
+    else:
+        print("This script requires Python v3.5+")

--- a/api_examples/python/get-resource-cmdb/requirements.txt
+++ b/api_examples/python/get-resource-cmdb/requirements.txt
@@ -1,0 +1,4 @@
+Click>=8.1.6
+requests>=2.31.0
+xdg>=6.0.0
+PyYAML>=6.0.1


### PR DESCRIPTION
## Summary
- Adds a new Python API example that looks up a Guardrails resource by its AKA (e.g. AWS ARN, Azure resource ID) and returns the full CMDB data
- Useful for integrations like SolarWinds or ServiceNow that need to pull resource configuration from the Guardrails GraphQL API
- Uses the `resource(id:)` query which accepts AKAs directly, keeping the script simple

## Test plan
- [x] Tested against live workspace (demo-turbot) with an EC2 instance ARN
- [x] Verified formatted text output shows summary, tags, and full CMDB data
- [x] Verified `--json-output` flag returns valid JSON
- [x] Verified not-found case returns clear error message

Ref: ZD #7709

🤖 Generated with [Claude Code](https://claude.com/claude-code)