### PR TITLE
Add Python example: control summaries by resource type

### DIFF
--- a/api_examples/python/control-summaries-by-resource-type/README.md
+++ b/api_examples/python/control-summaries-by-resource-type/README.md
@@ -1,0 +1,103 @@
+# Control Summaries by Resource Type
+
+Queries control summaries grouped by resource type and exports the results to a CSV file. Useful for compliance reporting and dashboards that need a breakdown of control states (ok, alarm, error, etc.) per resource type.
+
+## Prerequisites
+
+- [Python 3.\*.\*](https://www.python.org/downloads/)
+- [Pip](https://pip.pypa.io/en/stable/installing/)
+
+## Setup
+
+### Virtual environment
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Turbot configuration
+
+Setup environment variables for your Turbot installation:
+
+```shell
+export TURBOT_GRAPHQL_ENDPOINT="https://demo-acme.cloud.turbot.com/api/latest/graphql"
+export TURBOT_ACCESS_KEY_ID=12345678-1a2b-3c4b-5e6f-111222333444
+export TURBOT_SECRET_ACCESS_KEY=12345678-1a2b-3c4b-5e6f-111222333444
+```
+
+## Running the example
+
+```shell
+python3 control_summaries_by_resource_type.py
+```
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-c`, `--config-file` | Path to an optional yaml config file. |
+| `-p`, `--profile` | Profile to use from the config file. Default: `default`. |
+| `--csp` | Cloud service provider: `aws`, `azure`, or `gcp`. Default: `aws`. |
+| `--state` | Control states to include, comma-delimited. Default: `active`. e.g. `alarm,error,invalid`. |
+| `-s`, `--sort` | Sort order for results. Default: `-total` (descending by total). |
+| `-l`, `--limit` | Maximum number of resource types to return. Default: `100`. |
+| `-o`, `--output` | Output CSV file path. Default: `control_summaries.csv`. |
+
+### Examples
+
+#### Default: Top 5 AWS resource types by total controls
+
+```shell
+python3 control_summaries_by_resource_type.py
+```
+
+#### Azure resource types
+
+```shell
+python3 control_summaries_by_resource_type.py --csp azure
+```
+
+#### Only resource types with alarm or error controls
+
+```shell
+python3 control_summaries_by_resource_type.py --csp aws --state alarm,error
+```
+
+#### GCP resource types sorted by alarm count, output to custom file
+
+```shell
+python3 control_summaries_by_resource_type.py \
+  --csp gcp \
+  --sort "-alarm" \
+  --limit 20 \
+  --output gcp_alarm_report.csv
+```
+
+#### Use a specific profile
+
+```shell
+python3 control_summaries_by_resource_type.py \
+  --csp aws \
+  --profile prod \
+  --config-file /path/to/config.yml
+```
+
+## CSV Output
+
+The output CSV file contains the following columns:
+
+| Column | Description |
+| ------ | ----------- |
+| `resource_type_title` | Display name of the resource type. |
+| `resource_type_uri` | The Guardrails resource type URI. |
+| `resource_type_id` | The Guardrails resource type ID. |
+| `trunk` | The resource type hierarchy path. |
+| `total` | Total number of controls. |
+| `ok` | Controls in OK state. |
+| `alarm` | Controls in Alarm state. |
+| `error` | Controls in Error state. |
+| `invalid` | Controls in Invalid state. |
+| `tbd` | Controls in TBD state. |
+| `skipped` | Controls in Skipped state. |

--- a/api_examples/python/control-summaries-by-resource-type/control_summaries_by_resource_type.py
+++ b/api_examples/python/control-summaries-by-resource-type/control_summaries_by_resource_type.py
@@ -1,0 +1,222 @@
+import turbot
+import click
+import csv
+import requests
+import sys
+
+
+CSP_RESOURCE_TYPES = {
+    'aws': "tmod:@turbot/aws#/resource/types/aws",
+    'azure': "tmod:@turbot/azure#/resource/types/azure",
+    'gcp': "tmod:@turbot/gcp#/resource/types/gcp",
+}
+
+
+@click.command()
+@click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="[String] Pass an optional yaml config file.")
+@click.option('-p', '--profile', default="default", help="[String] Profile to be used from config file.")
+@click.option('--csp', default="aws", type=click.Choice(['aws', 'azure', 'gcp'], case_sensitive=False), help="[String] Cloud service provider. Default: aws.")
+@click.option('--state', default="active", help="[String] Control states to include, comma-delimited. Default: active. e.g. alarm,error,invalid")
+@click.option('-s', '--sort', default="-total", help="[String] Sort order for results. Default: -total (descending by total).")
+@click.option('-l', '--limit', default=100, type=int, help="[Int] Maximum number of resource types to return.")
+@click.option('-o', '--output', default="control_summaries.csv", help="[String] Output CSV file path.")
+def control_summaries_by_resource_type(config_file, profile, csp, state, sort, limit, output):
+    """Queries control summaries grouped by resource type and exports results to CSV."""
+
+    resource_type_id = CSP_RESOURCE_TYPES[csp.lower()]
+    filter = "resourceTypeId:'{}' state:{}".format(resource_type_id, state)
+
+    config = turbot.Config(config_file, profile)
+    headers = {'Authorization': 'Basic {}'.format(config.auth_token)}
+    endpoint = config.graphql_endpoint
+
+    query = '''
+      query ControlSummariesByResourceType($filter: [String!], $paging: String) {
+        controlSummaries: controlSummariesByResourceType(
+          filter: $filter
+          paging: $paging
+        ) {
+          metadata {
+            stats {
+              control {
+                total
+              }
+            }
+          }
+          items {
+            mode: type {
+              uri
+              trunk {
+                title
+                items {
+                  turbot {
+                    id
+                    title
+                  }
+                }
+              }
+              turbot {
+                id
+                title
+              }
+            }
+            summary {
+              control {
+                total
+                alarm
+                invalid
+                error
+                ok
+                skipped
+                tbd
+              }
+            }
+          }
+          paging {
+            next
+          }
+        }
+      }
+    '''
+
+    items = []
+    paging = None
+    filter_parts = ["sort:{} limit:{}".format(sort, limit), filter]
+
+    print("Looking for control summaries...")
+
+    while True:
+        variables = {'filter': filter_parts, 'paging': paging}
+        result = run_query(endpoint, headers, query, variables)
+
+        if "errors" in result:
+            for error in result['errors']:
+                print(error)
+            break
+
+        data = result['data']['controlSummaries']
+
+        if not items and data.get('metadata', {}).get('stats', {}).get('control', {}).get('total'):
+            total = data['metadata']['stats']['control']['total']
+            print("Total controls matching filter: {}".format(total))
+
+        for item in data['items']:
+            items.append(item)
+            if len(items) >= limit:
+                break
+
+        if len(items) >= limit or not data['paging']['next']:
+            break
+        else:
+            print("{} resource types found...".format(len(items)))
+            paging = data['paging']['next']
+
+    items = items[:limit]
+
+    print("\nFound {} resource type(s)".format(len(items)))
+
+    if not items:
+        print("No results to export.")
+        return
+
+    rows = []
+    for item in items:
+        controls = item['summary']['control']
+        trunk_titles = " > ".join(
+            t['turbot']['title'] for t in item['mode']['trunk']['items']
+        ) if item['mode']['trunk']['items'] else ""
+        rows.append({
+            'resource_type_title': item['mode']['turbot']['title'],
+            'resource_type_uri': item['mode']['uri'],
+            'resource_type_id': item['mode']['turbot']['id'],
+            'trunk': trunk_titles,
+            'total': controls['total'],
+            'ok': controls['ok'],
+            'alarm': controls['alarm'],
+            'error': controls['error'],
+            'invalid': controls['invalid'],
+            'tbd': controls['tbd'],
+            'skipped': controls['skipped'],
+        })
+
+    table_columns = ['resource_type_title', 'total', 'ok', 'alarm', 'error', 'invalid', 'tbd', 'skipped']
+    col_headers = {
+        'resource_type_title': 'Resource Type',
+        'total': 'Total',
+        'ok': 'OK',
+        'alarm': 'Alarm',
+        'error': 'Error',
+        'invalid': 'Invalid',
+        'tbd': 'TBD',
+        'skipped': 'Skipped',
+    }
+    col_widths = {}
+    for col in table_columns:
+        col_widths[col] = max(
+            len(col_headers[col]),
+            max(len(str(row[col])) for row in rows)
+        )
+
+    header_line = "  ".join(col_headers[col].ljust(col_widths[col]) if col == 'resource_type_title'
+                            else col_headers[col].rjust(col_widths[col])
+                            for col in table_columns)
+    separator = "  ".join("-" * col_widths[col] for col in table_columns)
+
+    print("\n{}".format(header_line))
+    print(separator)
+    for row in rows:
+        line = "  ".join(str(row[col]).ljust(col_widths[col]) if col == 'resource_type_title'
+                         else str(row[col]).rjust(col_widths[col])
+                         for col in table_columns)
+        print(line)
+
+    csv_columns = [
+        'resource_type_title',
+        'resource_type_uri',
+        'resource_type_id',
+        'trunk',
+        'total',
+        'ok',
+        'alarm',
+        'error',
+        'invalid',
+        'tbd',
+        'skipped',
+    ]
+
+    with open(output, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+    print("\nResults written to {}".format(output))
+
+
+def run_query(endpoint, headers, query, variables):
+    request = requests.post(
+        endpoint,
+        headers=headers,
+        json={'query': query, 'variables': variables}
+    )
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise Exception("Query failed to run by returning code of {}. {}".format(
+            request.status_code, query))
+
+
+if __name__ == "__main__":
+    if (sys.version_info > (3, 4)):
+        try:
+            control_summaries_by_resource_type()
+        except Exception as e:
+            print(e)
+    else:
+        print("This script requires Python v3.5+")
+        print("Your Python version is: {}.{}.{}".format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro))
+        if (sys.version_info < (3, 0)):
+            hint = ["Maybe try: `python3"] + sys.argv
+            hint[len(sys.argv)] = hint[len(sys.argv)] + "`"
+            print(*hint)

--- a/api_examples/python/control-summaries-by-resource-type/requirements.txt
+++ b/api_examples/python/control-summaries-by-resource-type/requirements.txt
@@ -1,0 +1,4 @@
+Click>=8.1.6
+requests>=2.31.0
+xdg>=6.0.0
+PyYAML>=6.0.1

--- a/api_examples/python/control-summaries-by-resource-type/turbot.py
+++ b/api_examples/python/control-summaries-by-resource-type/turbot.py
@@ -1,0 +1,111 @@
+import os
+from base64 import b64encode
+from xdg import XDG_CONFIG_HOME
+import yaml
+import requests
+
+
+class Config:
+    """ Locates the users Turbot credentials, verifies connectivity to
+        the specified Turbot workspace and instantiates a config object. """
+
+    def __init__(self, custom_config_file, config_profile):
+
+        config_dict = {}
+        config_fail = ""
+        turbot_config = "{}/turbot/credentials.yml".format(XDG_CONFIG_HOME)
+        graphql_path = 'api/latest/graphql'
+        health_path = 'api/latest/turbot/health'
+
+        # Option 1: Use custom yaml configuration file.
+        if custom_config_file:
+            with open(custom_config_file, 'r') as stream:
+                try:
+                    config_dict = yaml.safe_load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
+
+        # Option 2: Use environment variables
+        elif (os.getenv("TURBOT_ACCESS_KEY_ID") and os.getenv("TURBOT_SECRET_ACCESS_KEY")):
+            config_dict[config_profile] = {}
+            config_dict[config_profile]['accessKey'] = os.getenv(
+                "TURBOT_ACCESS_KEY_ID")
+            config_dict[config_profile]['secretKey'] = os.getenv(
+                "TURBOT_SECRET_ACCESS_KEY")
+
+            # Option 2a: Use TURBOT_WORKSPACE environment variable
+            if os.getenv("TURBOT_WORKSPACE"):
+                config_dict[config_profile]['workspace'] = os.getenv(
+                    "TURBOT_WORKSPACE")
+
+            # Option 2b: Use TURBOT_GRAPHQL_ENDPOINT environment variable
+            elif os.getenv("TURBOT_GRAPHQL_ENDPOINT"):
+                if os.getenv("TURBOT_GRAPHQL_ENDPOINT").endswith(graphql_path):
+                    config_dict[config_profile]['workspace'] = os.getenv(
+                        "TURBOT_GRAPHQL_ENDPOINT")[:-len(graphql_path)]
+                else:
+                    config_fail = "Incorrect TURBOT_GRAPHQL_ENDPOINT format, exiting..."
+            else:
+                config_fail = "No workspace found in environment vars, exiting..."
+
+        # Option 3: Use Turbot xdg configuration file (e.g. ~/.config/turbot/configuration.yml)
+        elif os.path.exists(turbot_config):
+            with open(turbot_config, 'r') as stream:
+                try:
+                    config_dict = yaml.safe_load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
+
+        if len(config_fail):
+            print(config_fail)
+            exit()
+
+        if config_dict:
+
+            if not config_profile in config_dict:
+                config_fail = "No matching profile, exiting..."
+
+            if not all(k in config_dict[config_profile] for k in ("workspace", "accessKey", "secretKey")):
+                config_fail = "Incorrect config file format, exiting..."
+
+            if len(config_fail):
+                print(config_fail)
+                exit()
+
+            self.workspace = config_dict[config_profile]['workspace']
+            self.accessKey = config_dict[config_profile]['accessKey']
+            self.secretKey = config_dict[config_profile]['secretKey']
+            # Set and Test Endpoints
+            if self.workspace.endswith("/"):
+                self.graphql_endpoint = "{}{}".format(
+                    self.workspace, graphql_path)
+                self.health_endpoint = "{}{}".format(
+                    self.workspace, health_path)
+            else:
+                self.graphql_endpoint = "{}/{}".format(
+                    self.workspace, graphql_path)
+                self.health_endpoint = "{}/{}".format(
+                    self.workspace, health_path)
+
+            print("Testing connection to {} ...".format(self.workspace))
+            self.test_health()
+            auth_bytes = '{}:{}'.format(
+                self.accessKey, self.secretKey).encode("utf-8")
+            self.auth_token = b64encode(auth_bytes).decode()
+
+        else:
+            print("Failed to find suitable configuration, please see README")
+            exit()
+
+    def test_health(self):
+        try:
+            r = requests.get(self.health_endpoint)
+        except requests.exceptions.ConnectionError:
+            print("Failed to connect, exiting.")
+            exit()
+
+        if r.status_code == requests.codes.ok:
+            print("Success! Status Code: {}".format(r.status_code))
+        else:
+            print("Failure! Status Code: {}".format(r.status_code))
+            r.raise_for_status()


### PR DESCRIPTION
## Summary
- Adds a new Python API example that queries control summaries grouped by resource type via the Guardrails GraphQL API
- Outputs results as a formatted terminal table and exports to CSV with full details (URI, ID, trunk path, control state counts)
- Supports `--csp` flag for AWS/Azure/GCP, `--state` for filtering control states (comma-delimited), `--limit` for result count, and `--sort` for ordering

## Test plan
- [x] Tested against `demo-turbot` workspace with `--csp aws --limit 10`
- [x] Tested against `demo-turbot` workspace with `--csp azure --limit 3`
- [x] Verified CSV output contains correct columns and data
- [x] Verified `--limit` correctly caps total results
- [x] Test with `--csp gcp`
- [x] Test `--state` with comma-delimited values (e.g. `alarm,error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)