### PR TITLE
Add Python example: control detail by state CSV export

### DIFF
--- a/api_examples/python/control-detail-by-state-export/README.md
+++ b/api_examples/python/control-detail-by-state-export/README.md
@@ -1,0 +1,97 @@
+# Control Detail by State Export
+
+Lists controls filtered by state and exports detailed information to a CSV file. Includes control type hierarchy, resource AKA, resource hierarchy path, and state change timestamp for each control.
+
+## Prerequisites
+
+- [Python 3.*.*](https://www.python.org/downloads/)
+- [Pip](https://pip.pypa.io/en/stable/installing/)
+
+## Setup
+
+### Virtual environment
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Turbot configuration
+
+Setup environment variables for your Turbot installation:
+
+```shell
+export TURBOT_GRAPHQL_ENDPOINT="https://demo-acme.cloud.turbot.com/api/latest/graphql"
+export TURBOT_ACCESS_KEY_ID=12345678-1a2b-3c4b-5e6f-111222333444
+export TURBOT_SECRET_ACCESS_KEY=12345678-1a2b-3c4b-5e6f-111222333444
+```
+
+## Running the example
+
+```shell
+python3 control_detail_by_state_export.py
+```
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-c`, `--config-file` | Path to an optional yaml config file. |
+| `-p`, `--profile` | Profile to use from the config file. Default: `default`. |
+| `--state` | Control states to filter, comma-delimited. Default: `alarm`. e.g. `alarm,invalid`. |
+| `--control-type` | Control type ID to filter. e.g. `tmod:@turbot/aws-events#/resource/types/target`. |
+| `-l`, `--limit` | Maximum number of controls to return. Default: `5000`. |
+| `--page-size` | Number of controls per API request. Default: `200`. |
+| `-o`, `--output` | Output CSV file path. Default: `control_detail_by_state.csv`. |
+
+### Examples
+
+#### Default: All alarm controls
+
+```shell
+python3 control_detail_by_state_export.py
+```
+
+#### Include alarm and invalid controls
+
+```shell
+python3 control_detail_by_state_export.py --state alarm,invalid
+```
+
+#### Filter by a specific control type
+
+```shell
+python3 control_detail_by_state_export.py --control-type "tmod:@turbot/aws-events#/resource/types/target"
+```
+
+#### Combine filters with custom output
+
+```shell
+python3 control_detail_by_state_export.py \
+  --state alarm,invalid \
+  --control-type "tmod:@turbot/aws-events#/resource/types/target" \
+  --limit 100 \
+  --output aws_events_alarm.csv
+```
+
+#### Use a specific profile
+
+```shell
+python3 control_detail_by_state_export.py \
+  --profile prod \
+  --config-file /path/to/config.yml
+```
+
+## CSV Output
+
+The output CSV file contains the following columns:
+
+| Column | Description |
+| ------ | ----------- |
+| `control_id` | The Guardrails control ID (formatted for Excel compatibility). |
+| `control_state` | Current control state (alarm, invalid, etc.). |
+| `control_type_trunk` | The control type hierarchy path (e.g. `AWS > HIPAA > IAM > ...`). |
+| `resource_aka` | The primary AKA (also-known-as) identifier for the resource. |
+| `resource_trunk` | The resource hierarchy path (e.g. `Turbot > Org > Folder > Account > Resource`). |
+| `state_change_timestamp` | When the control last changed state. |

--- a/api_examples/python/control-detail-by-state-export/control_detail_by_state_export.py
+++ b/api_examples/python/control-detail-by-state-export/control_detail_by_state_export.py
@@ -1,0 +1,236 @@
+import turbot
+import click
+import csv
+import requests
+import sys
+
+
+@click.command()
+@click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="[String] Pass an optional yaml config file.")
+@click.option('-p', '--profile', default="default", help="[String] Profile to be used from config file.")
+@click.option('--state', default="alarm", help="[String] Control states to filter, comma-delimited. Default: alarm. e.g. alarm,invalid")
+@click.option('--control-type', default=None, help="[String] Control type ID to filter. e.g. tmod:@turbot/aws-events#/resource/types/target")
+@click.option('-l', '--limit', default=5000, type=int, help="[Int] Maximum number of controls to return. Default: 5000.")
+@click.option('--page-size', default=200, type=int, help="[Int] Number of controls per API request. Default: 200.")
+@click.option('-o', '--output', default="control_detail_by_state.csv", help="[String] Output CSV file path.")
+def control_detail_by_state_export(config_file, profile, state, control_type, limit, page_size, output):
+    """Lists controls filtered by state and exports details to CSV."""
+
+    config = turbot.Config(config_file, profile)
+    headers = {'Authorization': 'Basic {}'.format(config.auth_token)}
+    endpoint = config.graphql_endpoint
+
+    query = '''
+      query ControlsList($filter: [String!], $paging: String) {
+        controls(filter: $filter, paging: $paging) {
+          metadata {
+            stats {
+              total
+            }
+          }
+          paging {
+            next
+          }
+          items {
+            state
+            reason
+            turbot {
+              id
+              createTimestamp
+              updateTimestamp
+              controlTypeId
+              resourceId
+              stateChangeTimestamp
+            }
+            type {
+              uri
+              title
+              icon
+              modUri
+              trunk {
+                title
+                items {
+                  turbot {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+            resource {
+              metadata
+              turbot {
+                id
+                title
+                akas
+              }
+              type {
+                uri
+                title
+                icon
+                trunk {
+                  items {
+                    turbot {
+                      id
+                      title
+                    }
+                  }
+                }
+              }
+              trunk {
+                items {
+                  turbot {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    '''
+
+    filter_parts = [
+        "state:{}".format(state),
+        "controlTypeLevel:self,descendant",
+        "controlCategoryLevel:self",
+        "limit:{}".format(page_size),
+    ]
+
+    if control_type:
+        filter_parts.append("controlTypeId:{}".format(control_type))
+
+    items = []
+    paging = None
+
+    print("Looking for controls in {} state...".format(state))
+
+    while True:
+        variables = {'filter': filter_parts, 'paging': paging}
+        result = run_query(endpoint, headers, query, variables)
+
+        if "errors" in result:
+            for error in result['errors']:
+                print(error)
+            break
+
+        data = result['data']['controls']
+
+        if not items and data.get('metadata', {}).get('stats', {}).get('total'):
+            total = data['metadata']['stats']['total']
+            print("Total controls matching filter: {}".format(total))
+
+        for item in data['items']:
+            items.append(item)
+            if len(items) >= limit:
+                break
+
+        if len(items) >= limit or not data['paging']['next']:
+            break
+        else:
+            print("{} controls fetched...".format(len(items)))
+            paging = data['paging']['next']
+
+    items = items[:limit]
+
+    print("\nFound {} control(s)".format(len(items)))
+
+    if not items:
+        print("No results to export.")
+        return
+
+    rows = []
+    for item in items:
+        control_trunk = " > ".join(
+            t['turbot']['title'] for t in item['type']['trunk']['items']
+        ) if item['type'].get('trunk', {}).get('items') else ""
+
+        resource = item.get('resource') or {}
+        resource_turbot = resource.get('turbot') or {}
+
+        resource_trunk = " > ".join(
+            t['turbot']['title'] for t in resource['trunk']['items']
+        ) if resource.get('trunk', {}).get('items') else ""
+
+        akas = resource_turbot.get('akas') or []
+
+        rows.append({
+            'control_id': '="' + str(item['turbot']['id']) + '"',
+            'control_state': item['state'],
+            'control_type_trunk': control_trunk,
+            'resource_aka': akas[0] if akas else '',
+            'resource_trunk': resource_trunk,
+            'state_change_timestamp': item['turbot'].get('stateChangeTimestamp') or '',
+        })
+
+    table_columns = ['control_state', 'control_type_trunk', 'resource_aka', 'state_change_timestamp']
+    col_headers = {
+        'control_state': 'State',
+        'control_type_trunk': 'Control Type',
+        'resource_aka': 'Resource AKA',
+        'state_change_timestamp': 'State Changed',
+    }
+    col_widths = {}
+    for col in table_columns:
+        col_widths[col] = max(
+            len(col_headers[col]),
+            max((len(str(row[col])[:60]) for row in rows), default=0)
+        )
+
+    header_line = "  ".join(col_headers[col].ljust(col_widths[col]) for col in table_columns)
+    separator = "  ".join("-" * col_widths[col] for col in table_columns)
+
+    print("\n{}".format(header_line))
+    print(separator)
+    for row in rows[:50]:
+        line = "  ".join(str(row[col])[:60].ljust(col_widths[col]) for col in table_columns)
+        print(line)
+    if len(rows) > 50:
+        print("... ({} more rows in CSV)".format(len(rows) - 50))
+
+    csv_columns = [
+        'control_id',
+        'control_state',
+        'control_type_trunk',
+        'resource_aka',
+        'resource_trunk',
+        'state_change_timestamp',
+    ]
+
+    with open(output, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+    print("\nResults written to {}".format(output))
+
+
+def run_query(endpoint, headers, query, variables):
+    request = requests.post(
+        endpoint,
+        headers=headers,
+        json={'query': query, 'variables': variables}
+    )
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise Exception("Query failed to run by returning code of {}. {}".format(
+            request.status_code, query))
+
+
+if __name__ == "__main__":
+    if (sys.version_info > (3, 4)):
+        try:
+            control_detail_by_state_export()
+        except Exception as e:
+            print(e)
+    else:
+        print("This script requires Python v3.5+")
+        print("Your Python version is: {}.{}.{}".format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro))
+        if (sys.version_info < (3, 0)):
+            hint = ["Maybe try: `python3"] + sys.argv
+            hint[len(sys.argv)] = hint[len(sys.argv)] + "`"
+            print(*hint)

--- a/api_examples/python/control-detail-by-state-export/requirements.txt
+++ b/api_examples/python/control-detail-by-state-export/requirements.txt
@@ -1,0 +1,4 @@
+Click>=8.1.6
+requests>=2.31.0
+xdg>=6.0.0
+PyYAML>=6.0.1

--- a/api_examples/python/control-detail-by-state-export/turbot.py
+++ b/api_examples/python/control-detail-by-state-export/turbot.py
@@ -1,0 +1,111 @@
+import os
+from base64 import b64encode
+from xdg import XDG_CONFIG_HOME
+import yaml
+import requests
+
+
+class Config:
+    """ Locates the users Turbot credentials, verifies connectivity to
+        the specified Turbot workspace and instantiates a config object. """
+
+    def __init__(self, custom_config_file, config_profile):
+
+        config_dict = {}
+        config_fail = ""
+        turbot_config = "{}/turbot/credentials.yml".format(XDG_CONFIG_HOME)
+        graphql_path = 'api/latest/graphql'
+        health_path = 'api/latest/turbot/health'
+
+        # Option 1: Use custom yaml configuration file.
+        if custom_config_file:
+            with open(custom_config_file, 'r') as stream:
+                try:
+                    config_dict = yaml.safe_load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
+
+        # Option 2: Use environment variables
+        elif (os.getenv("TURBOT_ACCESS_KEY_ID") and os.getenv("TURBOT_SECRET_ACCESS_KEY")):
+            config_dict[config_profile] = {}
+            config_dict[config_profile]['accessKey'] = os.getenv(
+                "TURBOT_ACCESS_KEY_ID")
+            config_dict[config_profile]['secretKey'] = os.getenv(
+                "TURBOT_SECRET_ACCESS_KEY")
+
+            # Option 2a: Use TURBOT_WORKSPACE environment variable
+            if os.getenv("TURBOT_WORKSPACE"):
+                config_dict[config_profile]['workspace'] = os.getenv(
+                    "TURBOT_WORKSPACE")
+
+            # Option 2b: Use TURBOT_GRAPHQL_ENDPOINT environment variable
+            elif os.getenv("TURBOT_GRAPHQL_ENDPOINT"):
+                if os.getenv("TURBOT_GRAPHQL_ENDPOINT").endswith(graphql_path):
+                    config_dict[config_profile]['workspace'] = os.getenv(
+                        "TURBOT_GRAPHQL_ENDPOINT")[:-len(graphql_path)]
+                else:
+                    config_fail = "Incorrect TURBOT_GRAPHQL_ENDPOINT format, exiting..."
+            else:
+                config_fail = "No workspace found in environment vars, exiting..."
+
+        # Option 3: Use Turbot xdg configuration file (e.g. ~/.config/turbot/configuration.yml)
+        elif os.path.exists(turbot_config):
+            with open(turbot_config, 'r') as stream:
+                try:
+                    config_dict = yaml.safe_load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
+
+        if len(config_fail):
+            print(config_fail)
+            exit()
+
+        if config_dict:
+
+            if not config_profile in config_dict:
+                config_fail = "No matching profile, exiting..."
+
+            if not all(k in config_dict[config_profile] for k in ("workspace", "accessKey", "secretKey")):
+                config_fail = "Incorrect config file format, exiting..."
+
+            if len(config_fail):
+                print(config_fail)
+                exit()
+
+            self.workspace = config_dict[config_profile]['workspace']
+            self.accessKey = config_dict[config_profile]['accessKey']
+            self.secretKey = config_dict[config_profile]['secretKey']
+            # Set and Test Endpoints
+            if self.workspace.endswith("/"):
+                self.graphql_endpoint = "{}{}".format(
+                    self.workspace, graphql_path)
+                self.health_endpoint = "{}{}".format(
+                    self.workspace, health_path)
+            else:
+                self.graphql_endpoint = "{}/{}".format(
+                    self.workspace, graphql_path)
+                self.health_endpoint = "{}/{}".format(
+                    self.workspace, health_path)
+
+            print("Testing connection to {} ...".format(self.workspace))
+            self.test_health()
+            auth_bytes = '{}:{}'.format(
+                self.accessKey, self.secretKey).encode("utf-8")
+            self.auth_token = b64encode(auth_bytes).decode()
+
+        else:
+            print("Failed to find suitable configuration, please see README")
+            exit()
+
+    def test_health(self):
+        try:
+            r = requests.get(self.health_endpoint)
+        except requests.exceptions.ConnectionError:
+            print("Failed to connect, exiting.")
+            exit()
+
+        if r.status_code == requests.codes.ok:
+            print("Success! Status Code: {}".format(r.status_code))
+        else:
+            print("Failure! Status Code: {}".format(r.status_code))
+            r.raise_for_status()


### PR DESCRIPTION
## Summary
- Adds a new Python API example that queries controls filtered by state (default: alarm) and exports details to CSV
- Supports pagination, configurable page size, control type filtering, and Excel-compatible control ID formatting
- Follows the same pattern as the existing `control-summaries-by-resource-type` example

## Test plan
- [x] Tested against demo-dev workspace, successfully fetched 998 alarm controls
- [x] Verified CSV output opens correctly in Excel with proper control ID formatting
- [x] Review CLI options and CSV columns for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)