### PR TITLE
Add Python example: export Turbot activity ledger with CSV export

### DIFF
--- a/api_examples/python/activity-ledger-export/README.md
+++ b/api_examples/python/activity-ledger-export/README.md
@@ -1,6 +1,11 @@
 # Activity Ledger Export
 
-Exports Turbot action notifications (the "Activity Ledger") for a configurable time window to a CSV file. Bypasses the 30-day / 5,000-row limits of the Guardrails UI by paginating through all results via the GraphQL API.
+Exports Turbot notifications to a CSV file. Bypasses the 30-day / 5,000-row limits of the Guardrails UI by paginating the GraphQL API with parallel workers, chunked date windows, streaming writes (no memory accumulation), and checkpoint/resume support.
+
+Two modes:
+
+- **Action notifications only** (default) — the Activity Ledger: enforcement actions taken by Turbot. Typically hundreds to low thousands per day. Parallelized by CSP root type.
+- **All notification types** (`--all-notifications`) — resource discoveries, control evaluations, policy changes, and enforcement actions combined. Typically hundreds of thousands per day. Parallelized by calendar day.
 
 ## Prerequisites
 
@@ -41,13 +46,21 @@ python3 activity_ledger_export.py --days 90
 | ------ | ----------- |
 | `-c`, `--config-file` | Path to an optional yaml config file. |
 | `-p`, `--profile` | Profile to use from the config file. Default: `default`. |
-| `--days` | Fetch activity from the last N days. Mutually exclusive with `--hours`. |
-| `--hours` | Fetch activity from the last N hours. Mutually exclusive with `--days`. |
-| `--actor-id` | Filter by a specific actor identity ID. Defaults to the Turbot Identity for the workspace. |
+| `--days` | Fetch activity from the last N days. When N exceeds `--chunk-days`, automatically uses chunked streaming mode. Mutually exclusive with `--hours` and `--from-date`. |
+| `--hours` | Fetch activity from the last N hours (action_notify only). Mutually exclusive with `--days`. |
+| `--from-date` | Start date `YYYY-MM-DD`. Mutually exclusive with `--days`/`--hours`. |
+| `--to-date` | End date `YYYY-MM-DD`. Used with `--from-date`. Defaults to today. |
+| `--chunk-days` | Process N days per chunk. Default: `7`. Large `--days` values are auto-split using this. |
+| `--resume` | Resume an interrupted run using the checkpoint file. |
+| `--actor-id` | Filter by a specific actor identity ID. Defaults to the Turbot Identity for the workspace (action_notify mode only). |
 | `--all-actors` | Include activity from all actors, not just Turbot Identity. |
-| `--csp` | Limit to a cloud provider's resources: `aws`, `azure`, or `gcp`. |
-| `--resource-type` | Filter by resource type IDs, comma-separated. Overrides `--csp`. |
-| `--page-size` | Number of notifications per API request. Default: `200`. |
+| `--all-notifications` | Export all notification types (resource, control, policy, action). Default: action_notify only. Uses date-based parallel workers; `--csp`/`--resource-type` are ignored. |
+| `--csp` | Limit to a specific platform: `aws`, `azure`, `azure-ad`, `gcp`, `kubernetes`, `servicenow`, `github`. Ignored with `--all-notifications`. |
+| `--resource-type` | Filter by resource type IDs, comma-separated. Overrides `--csp`. Ignored with `--all-notifications`. |
+| `--workers` | Parallel workers. For action_notify: one per CSP type (default 7). For `--all-notifications`: one per day per chunk (default 7). |
+| `--page-size` | Number of notifications per API request. Default: `500`. |
+| `--timeout` | Per-request HTTP timeout in seconds. Default: `120`. |
+| `--retries` | Max retries per request on transient errors (429/502/503/504/timeout). Default: `5`. |
 | `-o`, `--output` | Output CSV file path. Default: `activity_ledger.csv`. |
 
 ### Examples
@@ -58,7 +71,7 @@ python3 activity_ledger_export.py --days 90
 python3 activity_ledger_export.py --days 90
 ```
 
-The Turbot Identity actor ID is resolved automatically from the workspace.
+Auto-splits into 7-day chunks and streams rows directly to the CSV file. The Turbot Identity actor ID is resolved automatically from the workspace.
 
 #### Last 90 days, AWS resources only
 
@@ -72,13 +85,13 @@ python3 activity_ledger_export.py --days 90 --csp aws
 python3 activity_ledger_export.py --days 90 --all-actors
 ```
 
-#### Last 90 days, AWS and Azure resources, Turbot actor only
+#### Resume an interrupted run
 
 ```shell
-python3 activity_ledger_export.py \
-  --days 90 \
-  --resource-type "tmod:@turbot/aws#/resource/types/aws,tmod:@turbot/azure#/resource/types/azure"
+python3 activity_ledger_export.py --days 90 --resume
 ```
+
+A checkpoint file (`activity_ledger.csv.checkpoint.json`) is written after each chunk. `--resume` skips completed chunks and appends only the remaining data.
 
 #### Last 24 hours with a custom output file
 
@@ -86,37 +99,34 @@ python3 activity_ledger_export.py \
 python3 activity_ledger_export.py --hours 24 --output last_24h_activity.csv
 ```
 
-#### Use a specific credentials profile
+#### All notification types for 90 days (~60M rows)
 
 ```shell
-python3 activity_ledger_export.py --days 90 --profile prod
+python3 activity_ledger_export.py \
+  --all-notifications --days 90 \
+  --workers 7 --chunk-days 7 \
+  --all-actors \
+  --output all_notifications_90d.csv
 ```
 
-## Finding the Turbot Actor ID
+Uses date-based parallelization (one worker per calendar day within each 7-day chunk). Each day typically contains 600K–800K notifications in a large workspace. Estimated run time: ~11 hours for 90 days. Add `--resume` to restart safely after interruption.
 
-To find the actor identity ID for the Turbot system account (used to filter for automated Turbot actions only), run the following GraphQL query in the Guardrails API Explorer:
+#### Specific date range with chunking
 
-```graphql
-query GetTurbotActorId {
-  resources(filter: "resourceTypeId:tmod:@turbot/turbot#/resource/types/turbotDirectory limit:1") {
-    items {
-      turbot {
-        id
-        title
-      }
-    }
-  }
-}
+```shell
+python3 activity_ledger_export.py \
+  --from-date 2026-01-01 --to-date 2026-03-31 \
+  --chunk-days 7 --workers 7 \
+  -o q1_activity.csv
 ```
-
-Or use the query from the repository at `queries/notifications/get_turbot_actor_id.graphql`.
 
 ## CSV Output
 
 | Column | Description |
 | ------ | ----------- |
 | `notification_id` | Guardrails notification ID (formatted for Excel compatibility). |
-| `timestamp` | When the action occurred. |
+| `notification_type` | Notification type: `action_notify`, `control_notify`, `resource_notify`, `policy_notify`. |
+| `timestamp` | When the notification was created. |
 | `actor` | Identity that performed the action (e.g. `Turbot` or a user name). |
 | `message` | Description of the action taken. |
 | `resource_aka` | Primary AKA (ARN or equivalent) of the affected resource. |
@@ -124,3 +134,9 @@ Or use the query from the repository at `queries/notifications/get_turbot_actor_
 | `resource_type` | Resource type hierarchy (e.g. `AWS > S3 > Bucket`). |
 | `resource_trunk` | Full resource hierarchy path (e.g. `Turbot > Org > Account > Region > Bucket`). |
 | `detail_link` | Direct link to the notification in the Guardrails UI. |
+
+## Performance notes
+
+- **action_notify**: ~250–2,000 notifications per day in a large workspace. A 90-day run typically completes in 10–30 minutes.
+- **All notifications**: ~600K–800K per day in a large workspace. A 90-day run takes ~11 hours at 7 parallel workers. Each day is ~250 MB uncompressed CSV.
+- The API has a ~90-day retrieval window. Queries for older data will return 0 rows even if the count metadata shows records.

--- a/api_examples/python/activity-ledger-export/README.md
+++ b/api_examples/python/activity-ledger-export/README.md
@@ -4,7 +4,7 @@ Exports Turbot notifications to a CSV file. Bypasses the 30-day / 5,000-row limi
 
 Two modes:
 
-- **Action notifications only** (default) — the Activity Ledger: enforcement actions taken by Turbot. Typically hundreds to low thousands per day. Parallelized by CSP root type.
+- **Action notifications only** (default) — the Activity Ledger: enforcement actions taken by Turbot. Typically hundreds to low thousands per day. Without `--csp`, uses a single worker with no resource type filter. With `--csp`, parallelizes one worker per specified platform.
 - **All notification types** (`--all-notifications`) — resource discoveries, control evaluations, policy changes, and enforcement actions combined. Typically hundreds of thousands per day. Parallelized by calendar day.
 
 ## Prerequisites
@@ -55,9 +55,9 @@ python3 activity_ledger_export.py --days 90
 | `--actor-id` | Filter by a specific actor identity ID. Defaults to the Turbot Identity for the workspace (action_notify mode only). |
 | `--all-actors` | Include activity from all actors, not just Turbot Identity. |
 | `--all-notifications` | Export all notification types (resource, control, policy, action). Default: action_notify only. Uses date-based parallel workers; `--csp`/`--resource-type` are ignored. |
-| `--csp` | Limit to a specific platform: `aws`, `azure`, `azure-ad`, `gcp`, `kubernetes`, `servicenow`, `github`. Ignored with `--all-notifications`. |
+| `--csp` | Limit to one or more platforms: `aws`, `azure`, `azure-ad`, `gcp`, `kubernetes`, `servicenow`, `github`. Without this flag, all platforms are included with no resource type filter. |
 | `--resource-type` | Filter by resource type IDs, comma-separated. Overrides `--csp`. Ignored with `--all-notifications`. |
-| `--workers` | Parallel workers. For action_notify: one per CSP type (default 7). For `--all-notifications`: one per day per chunk (default 7). |
+| `--workers` | Parallel workers. For action_notify with `--csp`: one per platform (default 7). For `--all-notifications`: one per day per chunk (default 7). |
 | `--page-size` | Number of notifications per API request. Default: `500`. |
 | `--timeout` | Per-request HTTP timeout in seconds. Default: `120`. |
 | `--retries` | Max retries per request on transient errors (429/502/503/504/timeout). Default: `5`. |
@@ -77,6 +77,20 @@ Auto-splits into 7-day chunks and streams rows directly to the CSV file. The Tur
 
 ```shell
 python3 activity_ledger_export.py --days 90 --csp aws
+```
+
+#### Last 90 days, multiple platforms
+
+```shell
+python3 activity_ledger_export.py --days 90 --csp aws --csp azure --csp gcp
+```
+
+#### Filter by specific resource type IDs
+
+```shell
+python3 activity_ledger_export.py \
+  --from-date 2026-01-01 --to-date 2026-03-31 \
+  --resource-type 'tmod:@turbot/aws-s3#/resource/types/bucket,tmod:@turbot/aws-ec2#/resource/types/instance'
 ```
 
 #### Last 90 days, all actors (Turbot + human users)
@@ -135,8 +149,15 @@ python3 activity_ledger_export.py \
 | `resource_trunk` | Full resource hierarchy path (e.g. `Turbot > Org > Account > Region > Bucket`). |
 | `detail_link` | Direct link to the notification in the Guardrails UI. |
 
+## Row count vs. Guardrails console
+
+The row count in the exported CSV may differ from `metadata.stats.total` shown in the GraphQL console for the same filter. This is expected and the CSV is correct.
+
+`metadata.stats.total` is a DB-side count estimate that does not reliably match what the cursor actually returns — it can be higher or lower than the paginated count depending on the workspace. The script paginates until `paging.next` returns null (confirmed by a partial final page), meaning it retrieved everything the API will serve. The discrepancy is an API-side characteristic of `metadata.stats.total`, not a script limitation.
+
 ## Performance notes
 
-- **action_notify**: ~250–2,000 notifications per day in a large workspace. A 90-day run typically completes in 10–30 minutes.
+- **action_notify (no `--csp`)**: single worker, no resource type filter. Volume varies widely by workspace activity — from hundreds to tens of thousands per day.
+- **action_notify (with `--csp`)**: one parallel worker per specified platform, each filtered to that CSP's root resource type.
 - **All notifications**: ~600K–800K per day in a large workspace. A 90-day run takes ~11 hours at 7 parallel workers. Each day is ~250 MB uncompressed CSV.
 - The API has a ~90-day retrieval window. Queries for older data will return 0 rows even if the count metadata shows records.

--- a/api_examples/python/activity-ledger-export/README.md
+++ b/api_examples/python/activity-ledger-export/README.md
@@ -1,0 +1,126 @@
+# Activity Ledger Export
+
+Exports Turbot action notifications (the "Activity Ledger") for a configurable time window to a CSV file. Bypasses the 30-day / 5,000-row limits of the Guardrails UI by paginating through all results via the GraphQL API.
+
+## Prerequisites
+
+- [Python 3.*.*](https://www.python.org/downloads/)
+- [Pip](https://pip.pypa.io/en/stable/installing/)
+
+## Setup
+
+### Virtual environment
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Turbot configuration
+
+Set environment variables for your Turbot workspace:
+
+```shell
+export TURBOT_GRAPHQL_ENDPOINT="https://demo-acme.cloud.turbot.com/api/latest/graphql"
+export TURBOT_ACCESS_KEY_ID=12345678-1a2b-3c4b-5e6f-111222333444
+export TURBOT_SECRET_ACCESS_KEY=12345678-1a2b-3c4b-5e6f-111222333444
+```
+
+Or use a credentials profile from `~/.config/turbot/credentials.yml`.
+
+## Running the example
+
+```shell
+python3 activity_ledger_export.py --days 90
+```
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-c`, `--config-file` | Path to an optional yaml config file. |
+| `-p`, `--profile` | Profile to use from the config file. Default: `default`. |
+| `--days` | Fetch activity from the last N days. Mutually exclusive with `--hours`. |
+| `--hours` | Fetch activity from the last N hours. Mutually exclusive with `--days`. |
+| `--actor-id` | Filter by a specific actor identity ID. Defaults to the Turbot Identity for the workspace. |
+| `--all-actors` | Include activity from all actors, not just Turbot Identity. |
+| `--csp` | Limit to a cloud provider's resources: `aws`, `azure`, or `gcp`. |
+| `--resource-type` | Filter by resource type IDs, comma-separated. Overrides `--csp`. |
+| `--page-size` | Number of notifications per API request. Default: `200`. |
+| `-o`, `--output` | Output CSV file path. Default: `activity_ledger.csv`. |
+
+### Examples
+
+#### Last 90 days of Turbot Identity activity (default)
+
+```shell
+python3 activity_ledger_export.py --days 90
+```
+
+The Turbot Identity actor ID is resolved automatically from the workspace.
+
+#### Last 90 days, AWS resources only
+
+```shell
+python3 activity_ledger_export.py --days 90 --csp aws
+```
+
+#### Last 90 days, all actors (Turbot + human users)
+
+```shell
+python3 activity_ledger_export.py --days 90 --all-actors
+```
+
+#### Last 90 days, AWS and Azure resources, Turbot actor only
+
+```shell
+python3 activity_ledger_export.py \
+  --days 90 \
+  --resource-type "tmod:@turbot/aws#/resource/types/aws,tmod:@turbot/azure#/resource/types/azure"
+```
+
+#### Last 24 hours with a custom output file
+
+```shell
+python3 activity_ledger_export.py --hours 24 --output last_24h_activity.csv
+```
+
+#### Use a specific credentials profile
+
+```shell
+python3 activity_ledger_export.py --days 90 --profile prod
+```
+
+## Finding the Turbot Actor ID
+
+To find the actor identity ID for the Turbot system account (used to filter for automated Turbot actions only), run the following GraphQL query in the Guardrails API Explorer:
+
+```graphql
+query GetTurbotActorId {
+  resources(filter: "resourceTypeId:tmod:@turbot/turbot#/resource/types/turbotDirectory limit:1") {
+    items {
+      turbot {
+        id
+        title
+      }
+    }
+  }
+}
+```
+
+Or use the query from the repository at `queries/notifications/get_turbot_actor_id.graphql`.
+
+## CSV Output
+
+| Column | Description |
+| ------ | ----------- |
+| `notification_id` | Guardrails notification ID (formatted for Excel compatibility). |
+| `timestamp` | When the action occurred. |
+| `actor` | Identity that performed the action (e.g. `Turbot` or a user name). |
+| `message` | Description of the action taken. |
+| `resource_aka` | Primary AKA (ARN or equivalent) of the affected resource. |
+| `resource_title` | Display name of the affected resource. |
+| `resource_type` | Resource type hierarchy (e.g. `AWS > S3 > Bucket`). |
+| `resource_trunk` | Full resource hierarchy path (e.g. `Turbot > Org > Account > Region > Bucket`). |
+| `detail_link` | Direct link to the notification in the Guardrails UI. |

--- a/api_examples/python/activity-ledger-export/activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/activity_ledger_export.py
@@ -160,9 +160,9 @@ def fetch_window(endpoint, headers, base_filter_parts, hours_ago_start, hours_ag
     matching the original single-query behaviour.
     """
     if hours_ago_end == 0:
-        time_filter = "timestamp:>T-{}h".format(hours_ago_start)
+        time_filter = "timestamp:>=T-{}h".format(hours_ago_start)
     else:
-        time_filter = "timestamp:>T-{}h timestamp:<T-{}h".format(hours_ago_start, hours_ago_end)
+        time_filter = "timestamp:>=T-{}h timestamp:<T-{}h".format(hours_ago_start, hours_ago_end)
     filter_parts = base_filter_parts + [time_filter, "limit:{}".format(page_size)]
 
     items = []

--- a/api_examples/python/activity-ledger-export/activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/activity_ledger_export.py
@@ -1,16 +1,38 @@
 import turbot
 import click
 import csv
+import json
+import os
 import requests
 import sys
 import time
+import threading
+from datetime import datetime, timedelta
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 CSP_RESOURCE_TYPE_IDS = {
-    'aws':   'tmod:@turbot/aws#/resource/types/aws',
-    'azure': 'tmod:@turbot/azure#/resource/types/azure',
-    'gcp':   'tmod:@turbot/gcp#/resource/types/gcp',
+    'aws':        'tmod:@turbot/aws#/resource/types/aws',
+    'azure':      'tmod:@turbot/azure#/resource/types/azure',
+    'azure-ad':   'tmod:@turbot/azure-activedirectory#/resource/types/directory',
+    'gcp':        'tmod:@turbot/gcp#/resource/types/gcp',
+    'kubernetes': 'tmod:@turbot/kubernetes#/resource/types/kubernetes',
+    'servicenow': 'tmod:@turbot/servicenow#/resource/types/serviceNow',
+    'github':     'tmod:@turbot/github#/resource/types/github',
 }
+
+CSV_COLUMNS = [
+    'notification_id',
+    'notification_type',
+    'timestamp',
+    'actor',
+    'message',
+    'resource_aka',
+    'resource_title',
+    'resource_type',
+    'resource_trunk',
+    'detail_link',
+]
 
 NOTIFICATION_QUERY = '''
   query ActivityLedger($filter: [String!], $paging: String) {
@@ -57,6 +79,13 @@ NOTIFICATION_QUERY = '''
   }
 '''
 
+_print_lock = threading.Lock()
+
+
+def tprint(msg):
+    with _print_lock:
+        print(msg)
+
 
 def fmt_duration(seconds):
     if seconds < 60:
@@ -67,16 +96,37 @@ def fmt_duration(seconds):
         return "{}h {}m".format(int(seconds // 3600), int((seconds % 3600) // 60))
 
 
-def run_query(endpoint, headers, query, variables):
-    request = requests.post(
-        endpoint,
-        headers=headers,
-        json={'query': query, 'variables': variables}
-    )
-    if request.status_code == 200:
-        return request.json()
-    else:
-        raise Exception("Query failed with HTTP {}".format(request.status_code))
+def run_query(endpoint, headers, query, variables, timeout=120, max_retries=5):
+    """Execute a GraphQL query with timeout and exponential backoff retry."""
+    delay = 2
+    last_error = None
+    for attempt in range(max_retries):
+        try:
+            response = requests.post(
+                endpoint,
+                headers=headers,
+                json={'query': query, 'variables': variables},
+                timeout=timeout
+            )
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code in (429, 502, 503, 504):
+                last_error = "HTTP {}".format(response.status_code)
+                if attempt + 1 < max_retries:
+                    tprint("  {} — retry {}/{} in {}s".format(last_error, attempt + 1, max_retries, delay))
+                    time.sleep(delay)
+                    delay = min(delay * 2, 60)
+            else:
+                raise Exception("Query failed with HTTP {}".format(response.status_code))
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+            last_error = "{}: {}".format(type(e).__name__, e)
+            if attempt + 1 < max_retries:
+                tprint("  {} — retry {}/{} in {}s".format(type(e).__name__, attempt + 1, max_retries, delay))
+                time.sleep(delay)
+                delay = min(delay * 2, 60)
+            else:
+                break
+    raise Exception("Query failed after {} retries: {}".format(max_retries, last_error))
 
 
 def get_turbot_identity_id(endpoint, headers):
@@ -103,39 +153,296 @@ def get_turbot_identity_id(endpoint, headers):
     return str(items[0]['turbot']['id'])
 
 
-@click.command()
+def build_date_chunks(from_date_str, to_date_str, chunk_days):
+    """Return list of (chunk_from, chunk_to_exclusive) string pairs covering [from_date, to_date]."""
+    start = datetime.strptime(from_date_str, '%Y-%m-%d')
+    end   = datetime.strptime(to_date_str,   '%Y-%m-%d')
+    chunks = []
+    current = start
+    while current <= end:
+        chunk_end = min(current + timedelta(days=chunk_days), end + timedelta(days=1))
+        chunks.append((current.strftime('%Y-%m-%d'), chunk_end.strftime('%Y-%m-%d')))
+        current = chunk_end
+    return chunks
+
+
+def _paginate(endpoint, headers, filter_parts, label, page_size, progress, progress_key,
+              request_timeout=120, max_retries=5, write_fn=None):
+    """
+    Core pagination loop used by both worker types.
+
+    Streams results to write_fn (per page) if provided, otherwise accumulates and returns them.
+    progress_key is the counter name in the shared progress dict ('types_done' or 'days_done').
+    """
+    full_filter = filter_parts + ["limit:{}".format(page_size)]
+    items = []
+    item_count = 0
+    paging = None
+    page_num = 0
+    t_start = time.time()
+
+    while True:
+        variables = {'filter': full_filter, 'paging': paging}
+        try:
+            result = run_query(endpoint, headers, NOTIFICATION_QUERY, variables,
+                               timeout=request_timeout, max_retries=max_retries)
+        except Exception as e:
+            tprint("  [{}] Pagination stopped at page {}: {}".format(label, page_num + 1, e))
+            break
+
+        if "errors" in result:
+            for error in result['errors']:
+                tprint("  [{}] Error on page {}: {}".format(label, page_num + 1, error.get('message', error)))
+            break
+
+        data = result['data']['notifications']
+        page_items = data['items']
+        page_num += 1
+        item_count += len(page_items)
+
+        if write_fn:
+            write_fn(page_items)
+        else:
+            items.extend(page_items)
+
+        next_page = data['paging']['next'] if data.get('paging') else None
+        if not next_page:
+            break
+        paging = next_page
+
+    elapsed = time.time() - t_start
+    total_returned = item_count if write_fn else len(items)
+
+    with progress['lock']:
+        progress[progress_key] += 1
+        progress['items_fetched'] += total_returned
+        done = progress[progress_key]
+        total = progress['total_' + progress_key.replace('_done', '')]
+        total_items = progress['items_fetched']
+        run_elapsed = time.time() - progress['start_time']
+        rate = total_items / run_elapsed if run_elapsed > 0 else 0
+        tprint("  [{:>2}/{}] {:>22}  {:>8,} notifications  {:>6.1f}s  |  total so far: {:>9,}  ({:.0f}/s)".format(
+            done, total, label, total_returned, elapsed, total_items, rate))
+
+    return items
+
+
+def fetch_resource_type(endpoint, headers, base_filter_parts, resource_type_id, page_size, progress,
+                        request_timeout=120, max_retries=5, write_fn=None):
+    """Worker for action_notify mode: paginates one CSP root type within a date range."""
+    label = resource_type_id.split('@turbot/')[-1].split('#')[0] if '@turbot/' in resource_type_id else resource_type_id
+    filter_parts = base_filter_parts + ["resourceTypeId:'{}'".format(resource_type_id)]
+    return _paginate(endpoint, headers, filter_parts, label, page_size, progress,
+                     'types_done', request_timeout, max_retries, write_fn)
+
+
+def fetch_date_window(endpoint, headers, base_filter_parts, window_from, window_to, page_size, progress,
+                      request_timeout=120, max_retries=5, write_fn=None):
+    """Worker for all-notifications mode: paginates all records within a 1-day window."""
+    label = "{} → {}".format(window_from, window_to)
+    filter_parts = base_filter_parts + ["timestamp:>={} timestamp:<{}".format(window_from, window_to)]
+    return _paginate(endpoint, headers, filter_parts, label, page_size, progress,
+                     'days_done', request_timeout, max_retries, write_fn)
+
+
+def item_to_row(item, workspace_url):
+    """Convert a raw notification item to a CSV row dict."""
+    resource = item.get('resource') or {}
+    resource_turbot = resource.get('turbot') or {}
+    resource_type_data = resource.get('type') or {}
+    akas = resource_turbot.get('akas') or []
+
+    actor_title = ((item.get('actor') or {}).get('identity') or {}).get('title') or ''
+    turbot_data = item.get('turbot') or {}
+    notification_id = turbot_data.get('id') or ''
+    process_id = turbot_data.get('processId') or ''
+
+    return {
+        'notification_id':   str(notification_id),
+        'notification_type': item.get('notificationType') or '',
+        'timestamp':         item['turbot']['createTimestamp'],
+        'actor':             actor_title,
+        'message':           item.get('message') or '',
+        'resource_aka':      akas[0] if akas else '',
+        'resource_title':    resource_turbot.get('title', ''),
+        'resource_type':     (resource_type_data.get('trunk') or {}).get('title') or '',
+        'resource_trunk':    (resource.get('trunk') or {}).get('title') or '',
+        'detail_link':       "{}/apollo/processes/{}/notifications/{}".format(
+                                 workspace_url, process_id, notification_id) if process_id else '',
+    }
+
+
+def run_chunk(endpoint, headers, base_filter_parts, resource_type_ids,
+              chunk_from, chunk_to, page_size, workers,
+              chunk_label, chunk_num, total_chunks,
+              all_notifications=False,
+              request_timeout=120, max_retries=5, write_fn=None):
+    """
+    Fetch all notifications for one date chunk in parallel.
+
+    action_notify mode  (all_notifications=False):
+      One worker per CSP root type. base_filter_parts includes the time range.
+      Works correctly because action_notify notifications are tagged to the
+      accountable root resource type.
+
+    all-notifications mode (all_notifications=True):
+      One worker per day within the chunk. No resourceTypeId per worker.
+      Required because the resourceTypeId filter captures only root-type records
+      for non-action notification types; all other types need date-based splitting.
+    """
+    all_items = []
+
+    if all_notifications:
+        # Split chunk into 1-day sub-windows; each worker paginates one full day.
+        chunk_end_inclusive = (datetime.strptime(chunk_to, '%Y-%m-%d') - timedelta(days=1)).strftime('%Y-%m-%d')
+        day_windows = build_date_chunks(chunk_from, chunk_end_inclusive, 1)
+        actual_workers = min(workers, len(day_windows))
+        print("\nChunk {:>2}/{}: {}  ({} workers, {} days, all notification types)".format(
+            chunk_num, total_chunks, chunk_label, actual_workers, len(day_windows)))
+
+        progress = {
+            'lock':       threading.Lock(),
+            'days_done':  0,
+            'items_fetched': 0,
+            'total_days': len(day_windows),
+            'start_time': time.time(),
+        }
+
+        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+            futures = {
+                executor.submit(
+                    fetch_date_window,
+                    endpoint, headers, base_filter_parts, w_from, w_to,
+                    page_size, progress, request_timeout, max_retries, write_fn
+                ): (w_from, w_to)
+                for w_from, w_to in day_windows
+            }
+            for future in as_completed(futures):
+                try:
+                    result = future.result()
+                    if not write_fn:
+                        all_items.extend(result)
+                except Exception as e:
+                    tprint("  Worker error: {}".format(e))
+
+    else:
+        # One worker per CSP root type; base_filter_parts includes the time range.
+        actual_workers = min(workers, len(resource_type_ids))
+        print("\nChunk {:>2}/{}: {}  ({} workers, {} resource types)".format(
+            chunk_num, total_chunks, chunk_label, actual_workers, len(resource_type_ids)))
+
+        progress = {
+            'lock':        threading.Lock(),
+            'types_done':  0,
+            'items_fetched': 0,
+            'total_types': len(resource_type_ids),
+            'start_time':  time.time(),
+        }
+
+        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+            futures = {
+                executor.submit(
+                    fetch_resource_type,
+                    endpoint, headers, base_filter_parts, rt_id,
+                    page_size, progress, request_timeout, max_retries, write_fn
+                ): rt_id
+                for rt_id in resource_type_ids
+            }
+            for future in as_completed(futures):
+                try:
+                    result = future.result()
+                    if not write_fn:
+                        all_items.extend(result)
+                except Exception as e:
+                    tprint("  Worker error: {}".format(e))
+
+    if not write_fn:
+        all_items.sort(key=lambda x: x['turbot']['createTimestamp'], reverse=True)
+    return all_items
+
+
+@click.command(no_args_is_help=True)
 @click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="[String] Pass an optional yaml config file.")
 @click.option('-p', '--profile', default="default", help="[String] Profile to be used from config file.")
-@click.option('--days', default=7, type=int, show_default=True, help="[Int] Fetch activity from the last N days. e.g. 90. Mutually exclusive with --hours.")
-@click.option('--hours', default=None, type=int, help="[Int] Fetch activity from the last N hours. e.g. 24. Mutually exclusive with --days.")
+@click.option('--days', default=7, type=int, show_default=True, help="[Int] Fetch activity from the last N days. Mutually exclusive with --from-date/--hours.")
+@click.option('--hours', default=None, type=int, help="[Int] Fetch activity from the last N hours. Mutually exclusive with --days/--from-date.")
+@click.option('--from-date', default=None, help="[String] Start date YYYY-MM-DD. Mutually exclusive with --days/--hours.")
+@click.option('--to-date', default=None, help="[String] End date YYYY-MM-DD. Used with --from-date. Defaults to today.")
+@click.option('--chunk-days', default=7, type=int, show_default=True, help="[Int] Process N days per chunk. Default: 7.")
+@click.option('--resume', is_flag=True, default=False, help="Resume a previous interrupted run using the checkpoint file.")
 @click.option('--actor-id', default=None, help="[String] Filter by a specific actor identity ID. Defaults to the Turbot Identity for this workspace.")
 @click.option('--all-actors', is_flag=True, default=False, help="Include activity from all actors, not just Turbot Identity.")
-@click.option('--csp', default=None, type=click.Choice(['aws', 'azure', 'gcp'], case_sensitive=False), help="[String] Limit to a cloud provider's resources: aws, azure, or gcp. Mutually exclusive with --resource-type.")
-@click.option('--resource-type', default=None, help="[String] Filter by resource type IDs, comma-separated. Takes precedence over --csp. e.g. 'tmod:@turbot/aws#/resource/types/aws,tmod:@turbot/azure#/resource/types/azure'")
-@click.option('--page-size', default=500, type=int, show_default=True, help="[Int] Number of notifications per API request. Default: 500.")
+@click.option('--all-notifications', is_flag=True, default=False,
+              help="Export ALL notification types (resource, control, policy, action). "
+                   "Default: action_notify only. Use for large full-history exports.")
+@click.option('--csp', multiple=True,
+              type=click.Choice(['aws', 'azure', 'azure-ad', 'gcp', 'kubernetes', 'servicenow', 'github'],
+                                case_sensitive=False),
+              help="[String] Limit to one or more platforms. Ignored with --all-notifications "
+                   "(use post-export filtering instead).")
+@click.option('--resource-type', default=None,
+              help="[String] Filter by resource type IDs, comma-separated. Takes precedence over --csp. "
+                   "Ignored with --all-notifications.")
+@click.option('--workers', default=7, type=int, show_default=True,
+              help="[Int] Parallel workers. For action_notify: one per CSP type. "
+                   "For --all-notifications: one per day in each chunk. Default: 7.")
+@click.option('--page-size', default=500, type=int, show_default=True, help="[Int] Notifications per API request. Default: 500.")
+@click.option('--timeout', default=120, type=int, show_default=True, help="[Int] Per-request HTTP timeout in seconds. Default: 120.")
+@click.option('--retries', default=5, type=int, show_default=True, help="[Int] Max retries per request on transient errors. Default: 5.")
 @click.option('-o', '--output', default="activity_ledger.csv", help="[String] Output CSV file path. Default: activity_ledger.csv")
-def activity_ledger_export(config_file, profile, days, hours, actor_id, all_actors,
-                           csp, resource_type, page_size, output):
-    """Exports Turbot activity (action notifications) for the past N days or hours to a CSV file.
+def activity_ledger_export(config_file, profile, days, hours, from_date, to_date,
+                           chunk_days, resume, actor_id, all_actors, all_notifications,
+                           csp, resource_type, workers, page_size, timeout, retries, output):
+    """Exports Turbot notifications to a CSV file.
 
-    Bypasses the 30-day / 5000-row limits of the Activity Ledger UI by paginating
-    through all results via the GraphQL API.
+    \b
+    Action notifications only (Activity Ledger, default):
+      --days 90                         Last 90 days, Turbot Identity actor
+      --from-date 2026-01-01 --to-date 2026-03-31
 
-    By default, results are filtered to the Turbot Identity actor (automated Turbot
-    actions only). Use --all-actors to include actions by human users as well.
+    \b
+    All notification types (resource, control, policy, action):
+      --all-notifications --from-date 2026-01-01 --to-date 2026-03-31
+      --all-notifications --days 90 --workers 7
+
+    \b
+    Resume an interrupted run:
+      <same command as before> --resume
+
+    By default, action_notify results are filtered to the Turbot Identity actor.
+    Use --all-actors for human + automation activity. --all-notifications always
+    includes all actors unless --actor-id or --all-actors is explicitly set.
     """
 
-    if hours:
+    # Validate mutual exclusions
+    if from_date:
+        if hours or days != 7:
+            raise click.UsageError("--from-date is mutually exclusive with --days and --hours.")
+        if resume and not os.path.exists(output + '.checkpoint.json') and not os.path.exists(output):
+            raise click.UsageError("--resume specified but no checkpoint or output file found for '{}'.".format(output))
+    elif hours:
         if days != 7:
-            raise click.UsageError("--days and --hours are mutually exclusive. Use one or the other.")
-        time_filter = "timestamp:>=T-{}h".format(hours)
-        window_label = "last {} hours".format(hours)
-    else:
-        time_filter = "timestamp:>=T-{}h".format(days * 24)
-        window_label = "last {} days".format(days)
-
+            raise click.UsageError("--days and --hours are mutually exclusive.")
+        if all_notifications:
+            raise click.UsageError(
+                "--hours is not supported with --all-notifications (volumes are too large for a "
+                "sub-day window). Use --from-date / --to-date --chunk-days 1 instead.")
     if actor_id and all_actors:
         raise click.UsageError("--actor-id and --all-actors are mutually exclusive.")
+
+    # --all-notifications always uses the chunked streaming path regardless of --days size,
+    # because date-based parallelization requires whole-day boundaries and can't accumulate
+    # 700K+ records per day in memory.
+    if not from_date and not hours and all_notifications:
+        from_date = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+        # Include today as a full day by extending to_date to tomorrow
+        to_date = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')
+
+    # Auto-convert large --days to the chunked path (action_notify can buffer small windows)
+    elif not from_date and not hours and days > chunk_days:
+        from_date = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+        to_date = to_date or datetime.now().strftime('%Y-%m-%d')
+        print("Note: --days {} > --chunk-days {}; auto-switching to chunked streaming mode.".format(days, chunk_days))
 
     script_start = time.time()
 
@@ -144,164 +451,203 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
     endpoint = config.graphql_endpoint
     workspace_url = config.workspace.rstrip('/')
 
-    # Resolve actor filter: explicit ID > auto-lookup Turbot Identity > all actors
-    if not all_actors:
-        if not actor_id:
-            print("Looking up Turbot Identity actor ID...")
-            actor_id = get_turbot_identity_id(endpoint, headers)
-            if actor_id:
-                print("  Turbot Identity ID: {}".format(actor_id))
-            else:
-                print("  Warning: Could not resolve Turbot Identity. Falling back to all actors.")
+    # Resolve actor filter
+    # For all-notifications, default to all actors (no actor filter) unless explicitly set.
+    if not all_actors and not actor_id and not all_notifications:
+        print("Looking up Turbot Identity actor ID...")
+        actor_id = get_turbot_identity_id(endpoint, headers)
+        if actor_id:
+            print("  Turbot Identity ID: {}".format(actor_id))
+        else:
+            print("  Warning: Could not resolve Turbot Identity. Falling back to all actors.")
 
-    filter_parts = [
-        "notificationType:action_notify",
-        time_filter,
-        "limit:{}".format(page_size),
-    ]
-
+    # Determine resource type IDs for action_notify mode
     if resource_type:
-        type_ids = [t.strip() for t in resource_type.split(',')]
-        filter_parts.append("resourceTypeId:{}".format(','.join(type_ids)))
+        resource_type_ids = [t.strip() for t in resource_type.split(',')]
     elif csp:
-        filter_parts.append("resourceTypeId:{}".format(CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+        resource_type_ids = [CSP_RESOURCE_TYPE_IDS[c.lower()] for c in csp]
+    else:
+        resource_type_ids = list(CSP_RESOURCE_TYPE_IDS.values())
 
+    # Base filter (no time range, no resourceTypeId — added per worker)
+    base_filter_parts = [] if all_notifications else ["notificationType:action_notify"]
     if actor_id:
-        filter_parts.append("actorIdentityId:'{}'".format(actor_id))
+        base_filter_parts.append("actorIdentityId:'{}'".format(actor_id))
 
-    print("\nFetching Turbot activity for the {}...".format(window_label))
-    if actor_id:
-        print("  Actor filter         : {}".format(actor_id))
-    elif all_actors:
-        print("  Actor filter         : all actors")
-    if resource_type or csp:
-        print("  Resource type filter : {}".format(resource_type or CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+    if all_notifications and (csp or resource_type):
+        print("Note: --csp/--resource-type is ignored with --all-notifications.")
+        print("  The notifications API resourceTypeId filter only captures root account-type records")
+        print("  for non-action types. Filter by CSP in the exported CSV instead.")
 
-    items = []
-    paging = None
-    total_reported = None
-    fetch_start = time.time()
+    notification_mode = "all notification types" if all_notifications else "action_notify only"
+    actor_desc = actor_id if actor_id else ("all actors" if (all_actors or all_notifications) else "all actors (fallback)")
+    csp_desc = "all (date-based workers)" if all_notifications else ','.join(resource_type_ids)
 
-    while True:
-        variables = {'filter': filter_parts, 'paging': paging}
-        result = run_query(endpoint, headers, NOTIFICATION_QUERY, variables)
+    # -----------------------------------------------------------------------
+    # MODE 1: chunked path — --from-date or auto-converted large --days
+    # Streams writes directly to CSV per page (no in-memory accumulation).
+    # -----------------------------------------------------------------------
+    if from_date:
+        effective_to_date = to_date or datetime.now().strftime('%Y-%m-%d')
+        chunks = build_date_chunks(from_date, effective_to_date, chunk_days)
+        checkpoint_path = output + '.checkpoint.json'
 
-        if "errors" in result:
-            for error in result['errors']:
-                print("Error: {}".format(error.get('message', error)))
-            sys.exit(1)
+        completed_chunks = {}
+        if resume and os.path.exists(checkpoint_path):
+            try:
+                with open(checkpoint_path) as f:
+                    checkpoint = json.load(f)
+                completed_chunks = {c['chunk']: c['count'] for c in checkpoint.get('completed', [])}
+                print("Resuming — {} chunk(s) already completed.".format(len(completed_chunks)))
+            except (json.JSONDecodeError, KeyError):
+                print("Warning: checkpoint file is corrupt — starting from scratch.")
+                completed_chunks = {}
 
-        data = result['data']['notifications']
+        from_dt = datetime.strptime(from_date, '%Y-%m-%d')
+        days_ago = (datetime.now() - from_dt).days
+        if days_ago > 90:
+            print("\nWarning: --from-date {} is {} days ago.".format(from_date, days_ago))
+            print("  The API can COUNT notifications older than ~90 days but cannot RETRIEVE them.")
+            print("  Chunks outside that window will return 0 rows even if the DB total shows data.")
 
-        if total_reported is None:
-            total_reported = data.get('metadata', {}).get('stats', {}).get('total', 0)
-            print("  Total notifications  : {:,}\n".format(total_reported))
+        worker_desc = "{} per chunk (1 per day)".format(min(workers, chunk_days)) if all_notifications \
+                      else "{} per chunk (1 per CSP type)".format(min(workers, len(resource_type_ids)))
 
-        batch = data['items']
-        items.extend(batch)
+        print("\nExporting {} from {} to {}".format(notification_mode, from_date, effective_to_date))
+        print("  Actor filter    : {}".format(actor_desc))
+        print("  CSP / types     : {}".format(csp_desc))
+        print("  Chunks          : {} x {}-day windows".format(len(chunks), chunk_days))
+        print("  Workers         : {}".format(worker_desc))
+        print("  Timeout/Retries : {}s / {}".format(timeout, retries))
 
-        elapsed = time.time() - fetch_start
-        rate = len(items) / elapsed if elapsed > 0 else 0
-        eta = ((total_reported - len(items)) / rate) if rate > 0 and total_reported > len(items) else 0
-        print("  Fetched {:>8,} / {:>8,}  |  {:.0f}/s  |  elapsed: {}  |  ETA: {}".format(
-            len(items), total_reported,
-            rate,
-            fmt_duration(elapsed),
-            fmt_duration(eta) if eta > 0 else "done"
-        ))
+        file_mode = 'a' if resume and os.path.exists(output) else 'w'
+        csvfile = open(output, file_mode, newline='')
+        writer = csv.DictWriter(csvfile, fieldnames=CSV_COLUMNS)
+        if file_mode == 'w':
+            writer.writeheader()
 
-        next_page = data['paging']['next'] if data.get('paging') else None
-        if not next_page:
-            break
-        paging = next_page
+        total_written = sum(completed_chunks.values())
+        checkpoint_data = {'from_date': from_date, 'to_date': effective_to_date,
+                           'chunk_days': chunk_days, 'completed': [
+                               {'chunk': k, 'count': v} for k, v in completed_chunks.items()
+                           ]}
 
-    fetch_elapsed = time.time() - fetch_start
-    print("\nFetched {:,} notification(s) in {}.".format(len(items), fmt_duration(fetch_elapsed)))
+        write_lock = threading.Lock()
+        count_tracker = [0]
 
-    if total_reported and len(items) < total_reported * 0.95:
-        print("  Note: {:,} of {:,} total notifications were returned by the API.".format(
-            len(items), total_reported))
-        print("  This may reflect an API cache limit for short time windows. For complete")
-        print("  results, use a longer time range (--days 30 or more).")
+        def stream_write(page_items):
+            rows = [item_to_row(item, workspace_url) for item in page_items]
+            with write_lock:
+                for row in rows:
+                    writer.writerow(row)
+                count_tracker[0] += len(rows)
 
-    if not items:
-        print("No activity found for the specified filters.")
+        for idx, (chunk_from, chunk_to) in enumerate(chunks, 1):
+            chunk_key = "{}_{}".format(chunk_from, chunk_to)
+
+            if chunk_key in completed_chunks:
+                print("\nChunk {:>2}/{}: {} → {} [SKIP — {:,} rows already written]".format(
+                    idx, len(chunks), chunk_from, chunk_to, completed_chunks[chunk_key]))
+                continue
+
+            chunk_label = "{} → {}".format(chunk_from, chunk_to)
+
+            # For action_notify: pass time range in base filter; workers split by resource type.
+            # For all_notifications: pass time range to run_chunk; workers split by day.
+            if all_notifications:
+                chunk_base = base_filter_parts[:]
+            else:
+                time_filter = "timestamp:>={} timestamp:<{}".format(chunk_from, chunk_to)
+                chunk_base = base_filter_parts + [time_filter]
+
+            count_tracker[0] = 0
+            run_chunk(
+                endpoint, headers, chunk_base, resource_type_ids,
+                chunk_from, chunk_to, page_size, workers,
+                chunk_label, idx, len(chunks),
+                all_notifications=all_notifications,
+                request_timeout=timeout, max_retries=retries, write_fn=stream_write
+            )
+
+            csvfile.flush()
+            chunk_count = count_tracker[0]
+            total_written += chunk_count
+            completed_chunks[chunk_key] = chunk_count
+            checkpoint_data['completed'].append({'chunk': chunk_key, 'count': chunk_count})
+            with open(checkpoint_path, 'w') as f:
+                json.dump(checkpoint_data, f, indent=2)
+
+            run_elapsed = time.time() - script_start
+            chunks_remaining = len(chunks) - idx
+            rate_chunks = idx / run_elapsed if run_elapsed > 0 else 0
+            eta_secs = chunks_remaining / rate_chunks if rate_chunks > 0 else 0
+            print("  Chunk {}/{} done: {:,} rows  |  total: {:,}  |  elapsed: {}  |  ETA: {}".format(
+                idx, len(chunks), chunk_count, total_written,
+                fmt_duration(run_elapsed),
+                fmt_duration(eta_secs) if chunks_remaining > 0 else "done"))
+
+        csvfile.close()
+
+        if len(completed_chunks) == len(chunks) and os.path.exists(checkpoint_path):
+            os.remove(checkpoint_path)
+            print("\nAll chunks complete — checkpoint removed.")
+
+        total_elapsed = time.time() - script_start
+        print("\nResults written to {}".format(output))
+        print("Total time: {}  ({:,} notifications)".format(fmt_duration(total_elapsed), total_written))
         return
 
-    print("Sorting results...")
-    items.sort(key=lambda x: x['turbot']['createTimestamp'], reverse=True)
+    # -----------------------------------------------------------------------
+    # MODE 2: relative --hours or small --days (action_notify only, in-memory, with preview)
+    # Reached only for --hours N, or --days N where N <= chunk_days.
+    # --all-notifications always goes through MODE 1 (chunked streaming).
+    # -----------------------------------------------------------------------
+    if hours:
+        time_filter = "timestamp:>T-{}h".format(hours)
+        window_label = "last {} hours".format(hours)
+    else:
+        time_filter = "timestamp:>T-{}d".format(days)
+        window_label = "last {} days".format(days)
 
-    rows = []
-    for item in items:
-        resource = item.get('resource') or {}
-        resource_turbot = resource.get('turbot') or {}
-        resource_type_data = resource.get('type') or {}
-        akas = resource_turbot.get('akas') or []
-        resource_trunk = (resource.get('trunk') or {}).get('title') or ''
-        resource_type_trunk = (resource_type_data.get('trunk') or {}).get('title') or ''
+    relative_filter_parts = base_filter_parts + [time_filter]
 
-        actor = item.get('actor') or {}
-        identity = actor.get('identity') or {}
-        actor_title = identity.get('title') or ''
+    print("\nFetching {} for the {}...".format(notification_mode, window_label))
+    print("  Actor filter    : {}".format(actor_desc))
+    print("  CSP / types     : {}\n".format(csp_desc))
 
-        notification_id = item['turbot']['id']
-        process_id = item['turbot'].get('processId') or ''
-        detail_link = "{}/apollo/processes/{}/notifications/{}".format(
-            workspace_url, process_id, notification_id
-        ) if process_id else ''
+    all_items = run_chunk(
+        endpoint, headers, relative_filter_parts, resource_type_ids,
+        '', '', page_size, workers,
+        window_label, 1, 1,
+        all_notifications=False,
+        request_timeout=timeout, max_retries=retries
+    )
 
-        rows.append({
-            'notification_id':  str(notification_id),
-            'timestamp':        item['turbot']['createTimestamp'],
-            'actor':            actor_title,
-            'message':          item.get('message') or '',
-            'resource_aka':     akas[0] if akas else '',
-            'resource_title':   resource_turbot.get('title', ''),
-            'resource_type':    resource_type_trunk,
-            'resource_trunk':   resource_trunk,
-            'detail_link':      detail_link,
-        })
+    fetch_elapsed = time.time() - script_start
+    print("\nFetched {:,} notification(s) in {}.".format(len(all_items), fmt_duration(fetch_elapsed)))
 
-    # Print preview table
-    preview_cols = ['timestamp', 'actor', 'message', 'resource_aka']
-    col_headers = {
-        'timestamp':    'Timestamp',
-        'actor':        'Actor',
-        'message':      'Message',
-        'resource_aka': 'Resource AKA',
-    }
-    col_widths = {}
-    for col in preview_cols:
-        col_widths[col] = max(
-            len(col_headers[col]),
-            max((len(str(row[col])[:60]) for row in rows), default=0)
-        )
+    if not all_items:
+        print("No notifications found for the specified filters.")
+        return
 
-    header_line = "  ".join(col_headers[col].ljust(col_widths[col]) for col in preview_cols)
-    separator   = "  ".join("-" * col_widths[col] for col in preview_cols)
+    rows = [item_to_row(item, workspace_url) for item in all_items]
 
-    print("\n{}".format(header_line))
-    print(separator)
+    preview_cols = ['timestamp', 'notification_type', 'actor', 'message', 'resource_aka']
+    col_headers = {'timestamp': 'Timestamp', 'notification_type': 'Type',
+                   'actor': 'Actor', 'message': 'Message', 'resource_aka': 'Resource AKA'}
+    col_widths = {col: max(len(col_headers[col]),
+                           max((len(str(row[col])[:50]) for row in rows), default=0))
+                  for col in preview_cols}
+
+    print("\n{}".format("  ".join(col_headers[col].ljust(col_widths[col]) for col in preview_cols)))
+    print("  ".join("-" * col_widths[col] for col in preview_cols))
     for row in rows[:50]:
-        line = "  ".join(str(row[col])[:60].ljust(col_widths[col]) for col in preview_cols)
-        print(line)
+        print("  ".join(str(row[col])[:50].ljust(col_widths[col]) for col in preview_cols))
     if len(rows) > 50:
-        print("... ({} more rows in CSV)".format(len(rows) - 50))
-
-    csv_columns = [
-        'notification_id',
-        'timestamp',
-        'actor',
-        'message',
-        'resource_aka',
-        'resource_title',
-        'resource_type',
-        'resource_trunk',
-        'detail_link',
-    ]
+        print("... ({:,} more rows in CSV)".format(len(rows) - 50))
 
     with open(output, 'w', newline='') as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
+        writer = csv.DictWriter(csvfile, fieldnames=CSV_COLUMNS)
         writer.writeheader()
         for row in rows:
             writer.writerow(row)

--- a/api_examples/python/activity-ledger-export/activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/activity_ledger_export.py
@@ -193,6 +193,7 @@ def _paginate(endpoint, headers, filter_parts, label, page_size, progress, progr
         if "errors" in result:
             for error in result['errors']:
                 tprint("  [{}] Error on page {}: {}".format(label, page_num + 1, error.get('message', error)))
+            tprint("  [{}] Stopped after {} item(s) due to API error.".format(label, item_count))
             break
 
         data = result['data']['notifications']
@@ -260,7 +261,7 @@ def item_to_row(item, workspace_url):
     return {
         'notification_id':   str(notification_id),
         'notification_type': item.get('notificationType') or '',
-        'timestamp':         item['turbot']['createTimestamp'],
+        'timestamp':         turbot_data.get('createTimestamp') or '',
         'actor':             actor_title,
         'message':           item.get('message') or '',
         'resource_aka':      akas[0] if akas else '',
@@ -326,35 +327,54 @@ def run_chunk(endpoint, headers, base_filter_parts, resource_type_ids,
                     tprint("  Worker error: {}".format(e))
 
     else:
-        # One worker per CSP root type; base_filter_parts includes the time range.
-        actual_workers = min(workers, len(resource_type_ids))
-        print("\nChunk {:>2}/{}: {}  ({} workers, {} resource types)".format(
-            chunk_num, total_chunks, chunk_label, actual_workers, len(resource_type_ids)))
+        if resource_type_ids:
+            # One worker per CSP root type; base_filter_parts includes the time range.
+            actual_workers = min(workers, len(resource_type_ids))
+            print("\nChunk {:>2}/{}: {}  ({} workers, {} resource types)".format(
+                chunk_num, total_chunks, chunk_label, actual_workers, len(resource_type_ids)))
 
-        progress = {
-            'lock':        threading.Lock(),
-            'types_done':  0,
-            'items_fetched': 0,
-            'total_types': len(resource_type_ids),
-            'start_time':  time.time(),
-        }
-
-        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-            futures = {
-                executor.submit(
-                    fetch_resource_type,
-                    endpoint, headers, base_filter_parts, rt_id,
-                    page_size, progress, request_timeout, max_retries, write_fn
-                ): rt_id
-                for rt_id in resource_type_ids
+            progress = {
+                'lock':        threading.Lock(),
+                'types_done':  0,
+                'items_fetched': 0,
+                'total_types': len(resource_type_ids),
+                'start_time':  time.time(),
             }
-            for future in as_completed(futures):
-                try:
-                    result = future.result()
-                    if not write_fn:
-                        all_items.extend(result)
-                except Exception as e:
-                    tprint("  Worker error: {}".format(e))
+
+            with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+                futures = {
+                    executor.submit(
+                        fetch_resource_type,
+                        endpoint, headers, base_filter_parts, rt_id,
+                        page_size, progress, request_timeout, max_retries, write_fn
+                    ): rt_id
+                    for rt_id in resource_type_ids
+                }
+                for future in as_completed(futures):
+                    try:
+                        result = future.result()
+                        if not write_fn:
+                            all_items.extend(result)
+                    except Exception as e:
+                        tprint("  Worker error: {}".format(e))
+        else:
+            # No --csp/--resource-type: single worker, no resourceTypeId filter.
+            print("\nChunk {:>2}/{}: {}  (1 worker, all resource types)".format(
+                chunk_num, total_chunks, chunk_label))
+
+            progress = {
+                'lock':        threading.Lock(),
+                'types_done':  0,
+                'items_fetched': 0,
+                'total_types': 1,
+                'start_time':  time.time(),
+            }
+
+            result = _paginate(endpoint, headers, base_filter_parts, "all",
+                               page_size, progress, 'types_done',
+                               request_timeout, max_retries, write_fn)
+            if not write_fn:
+                all_items.extend(result)
 
     if not write_fn:
         all_items.sort(key=lambda x: x['turbot']['createTimestamp'], reverse=True)
@@ -418,8 +438,14 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
     if from_date:
         if hours or days != 7:
             raise click.UsageError("--from-date is mutually exclusive with --days and --hours.")
-        if resume and not os.path.exists(output + '.checkpoint.json') and not os.path.exists(output):
+        checkpoint_exists = os.path.exists(output + '.checkpoint.json')
+        output_exists = os.path.exists(output)
+        if resume and not checkpoint_exists and not output_exists:
             raise click.UsageError("--resume specified but no checkpoint or output file found for '{}'.".format(output))
+        if resume and output_exists and not checkpoint_exists:
+            raise click.UsageError(
+                "--resume found '{}' but no checkpoint file. Cannot safely resume — "
+                "re-running without --resume would overwrite the existing output.".format(output))
     elif hours:
         if days != 7:
             raise click.UsageError("--days and --hours are mutually exclusive.")
@@ -461,13 +487,14 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
         else:
             print("  Warning: Could not resolve Turbot Identity. Falling back to all actors.")
 
-    # Determine resource type IDs for action_notify mode
+    # Determine resource type IDs for action_notify mode.
+    # Empty list means no resourceTypeId filter (query all types unscoped).
     if resource_type:
         resource_type_ids = [t.strip() for t in resource_type.split(',')]
     elif csp:
         resource_type_ids = [CSP_RESOURCE_TYPE_IDS[c.lower()] for c in csp]
     else:
-        resource_type_ids = list(CSP_RESOURCE_TYPE_IDS.values())
+        resource_type_ids = []
 
     # Base filter (no time range, no resourceTypeId — added per worker)
     base_filter_parts = [] if all_notifications else ["notificationType:action_notify"]
@@ -481,7 +508,9 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
 
     notification_mode = "all notification types" if all_notifications else "action_notify only"
     actor_desc = actor_id if actor_id else ("all actors" if (all_actors or all_notifications) else "all actors (fallback)")
-    csp_desc = "all (date-based workers)" if all_notifications else ','.join(resource_type_ids)
+    csp_desc = "all (date-based workers)" if all_notifications else (
+        ','.join(resource_type_ids) if resource_type_ids else "all (no type filter)"
+    )
 
     # -----------------------------------------------------------------------
     # MODE 1: chunked path — --from-date or auto-converted large --days
@@ -510,12 +539,17 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
             print("  The API can COUNT notifications older than ~90 days but cannot RETRIEVE them.")
             print("  Chunks outside that window will return 0 rows even if the DB total shows data.")
 
-        worker_desc = "{} per chunk (1 per day)".format(min(workers, chunk_days)) if all_notifications \
-                      else "{} per chunk (1 per CSP type)".format(min(workers, len(resource_type_ids)))
+        if all_notifications:
+            worker_desc = "{} per chunk (1 per day)".format(min(workers, chunk_days))
+        elif resource_type_ids:
+            worker_desc = "{} per chunk (1 per CSP type)".format(min(workers, len(resource_type_ids)))
+        else:
+            worker_desc = "1 per chunk (no type filter)"
 
         print("\nExporting {} from {} to {}".format(notification_mode, from_date, effective_to_date))
         print("  Actor filter    : {}".format(actor_desc))
         print("  CSP / types     : {}".format(csp_desc))
+        print("  Base filter     : {}".format(base_filter_parts))
         print("  Chunks          : {} x {}-day windows".format(len(chunks), chunk_days))
         print("  Workers         : {}".format(worker_desc))
         print("  Timeout/Retries : {}s / {}".format(timeout, retries))
@@ -542,51 +576,57 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
                     writer.writerow(row)
                 count_tracker[0] += len(rows)
 
-        for idx, (chunk_from, chunk_to) in enumerate(chunks, 1):
-            chunk_key = "{}_{}".format(chunk_from, chunk_to)
+        try:
+            for idx, (chunk_from, chunk_to) in enumerate(chunks, 1):
+                chunk_key = "{}_{}".format(chunk_from, chunk_to)
 
-            if chunk_key in completed_chunks:
-                print("\nChunk {:>2}/{}: {} → {} [SKIP — {:,} rows already written]".format(
-                    idx, len(chunks), chunk_from, chunk_to, completed_chunks[chunk_key]))
-                continue
+                if chunk_key in completed_chunks:
+                    print("\nChunk {:>2}/{}: {} → {} [SKIP — {:,} rows already written]".format(
+                        idx, len(chunks), chunk_from, chunk_to, completed_chunks[chunk_key]))
+                    continue
 
-            chunk_label = "{} → {}".format(chunk_from, chunk_to)
+                chunk_label = "{} → {}".format(chunk_from, chunk_to)
 
-            # For action_notify: pass time range in base filter; workers split by resource type.
-            # For all_notifications: pass time range to run_chunk; workers split by day.
-            if all_notifications:
-                chunk_base = base_filter_parts[:]
-            else:
-                time_filter = "timestamp:>={} timestamp:<{}".format(chunk_from, chunk_to)
-                chunk_base = base_filter_parts + [time_filter]
+                # For action_notify: pass time range in base filter; workers split by resource type.
+                # For all_notifications: pass time range to run_chunk; workers split by day.
+                if all_notifications:
+                    chunk_base = base_filter_parts[:]
+                else:
+                    time_filter = "timestamp:>={} timestamp:<{}".format(chunk_from, chunk_to)
+                    chunk_base = base_filter_parts + [time_filter]
 
-            count_tracker[0] = 0
-            run_chunk(
-                endpoint, headers, chunk_base, resource_type_ids,
-                chunk_from, chunk_to, page_size, workers,
-                chunk_label, idx, len(chunks),
-                all_notifications=all_notifications,
-                request_timeout=timeout, max_retries=retries, write_fn=stream_write
-            )
+                worker_filter_note = "+ timestamp per worker" if all_notifications \
+                    else ("+ resourceTypeId per worker" if resource_type_ids else "")
+                print("  Filter          : {}{}".format(
+                    chunk_base, "  ({})".format(worker_filter_note) if worker_filter_note else ""))
 
-            csvfile.flush()
-            chunk_count = count_tracker[0]
-            total_written += chunk_count
-            completed_chunks[chunk_key] = chunk_count
-            checkpoint_data['completed'].append({'chunk': chunk_key, 'count': chunk_count})
-            with open(checkpoint_path, 'w') as f:
-                json.dump(checkpoint_data, f, indent=2)
+                count_tracker[0] = 0
+                run_chunk(
+                    endpoint, headers, chunk_base, resource_type_ids,
+                    chunk_from, chunk_to, page_size, workers,
+                    chunk_label, idx, len(chunks),
+                    all_notifications=all_notifications,
+                    request_timeout=timeout, max_retries=retries, write_fn=stream_write
+                )
 
-            run_elapsed = time.time() - script_start
-            chunks_remaining = len(chunks) - idx
-            rate_chunks = idx / run_elapsed if run_elapsed > 0 else 0
-            eta_secs = chunks_remaining / rate_chunks if rate_chunks > 0 else 0
-            print("  Chunk {}/{} done: {:,} rows  |  total: {:,}  |  elapsed: {}  |  ETA: {}".format(
-                idx, len(chunks), chunk_count, total_written,
-                fmt_duration(run_elapsed),
-                fmt_duration(eta_secs) if chunks_remaining > 0 else "done"))
+                csvfile.flush()
+                chunk_count = count_tracker[0]
+                total_written += chunk_count
+                completed_chunks[chunk_key] = chunk_count
+                checkpoint_data['completed'].append({'chunk': chunk_key, 'count': chunk_count})
+                with open(checkpoint_path, 'w') as f:
+                    json.dump(checkpoint_data, f, indent=2)
 
-        csvfile.close()
+                run_elapsed = time.time() - script_start
+                chunks_remaining = len(chunks) - idx
+                rate_chunks = idx / run_elapsed if run_elapsed > 0 else 0
+                eta_secs = chunks_remaining / rate_chunks if rate_chunks > 0 else 0
+                print("  Chunk {}/{} done: {:,} rows  |  total: {:,}  |  elapsed: {}  |  ETA: {}".format(
+                    idx, len(chunks), chunk_count, total_written,
+                    fmt_duration(run_elapsed),
+                    fmt_duration(eta_secs) if chunks_remaining > 0 else "done"))
+        finally:
+            csvfile.close()
 
         if len(completed_chunks) == len(chunks) and os.path.exists(checkpoint_path):
             os.remove(checkpoint_path)
@@ -613,7 +653,11 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
 
     print("\nFetching {} for the {}...".format(notification_mode, window_label))
     print("  Actor filter    : {}".format(actor_desc))
-    print("  CSP / types     : {}\n".format(csp_desc))
+    print("  CSP / types     : {}".format(csp_desc))
+    worker_filter_note = "+ resourceTypeId per worker" if resource_type_ids else ""
+    print("  Filter          : {}{}".format(
+        relative_filter_parts, "  ({})".format(worker_filter_note) if worker_filter_note else ""))
+    print()
 
     all_items = run_chunk(
         endpoint, headers, relative_filter_parts, resource_type_ids,
@@ -658,7 +702,7 @@ def activity_ledger_export(config_file, profile, days, hours, from_date, to_date
 
 
 if __name__ == "__main__":
-    if sys.version_info > (3, 4):
+    if sys.version_info >= (3, 5):
         try:
             activity_ledger_export()
         except Exception as e:

--- a/api_examples/python/activity-ledger-export/activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/activity_ledger_export.py
@@ -3,6 +3,9 @@ import click
 import csv
 import requests
 import sys
+import time
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 CSP_RESOURCE_TYPE_IDS = {
@@ -10,6 +13,79 @@ CSP_RESOURCE_TYPE_IDS = {
     'azure': 'tmod:@turbot/azure#/resource/types/azure',
     'gcp':   'tmod:@turbot/gcp#/resource/types/gcp',
 }
+
+NOTIFICATION_QUERY = '''
+  query ActivityLedger($filter: [String!], $paging: String) {
+    notifications(filter: $filter, paging: $paging) {
+      metadata {
+        stats {
+          total
+        }
+      }
+      paging {
+        next
+      }
+      items {
+        notificationType
+        message
+        turbot {
+          id
+          processId
+          createTimestamp
+        }
+        actor {
+          identity {
+            title
+          }
+        }
+        resource {
+          trunk {
+            title
+          }
+          turbot {
+            id
+            title
+            akas
+          }
+          type {
+            trunk {
+              title
+            }
+            uri
+          }
+        }
+      }
+    }
+  }
+'''
+
+_print_lock = threading.Lock()
+
+
+def tprint(msg):
+    with _print_lock:
+        print(msg)
+
+
+def fmt_duration(seconds):
+    if seconds < 60:
+        return "{}s".format(int(seconds))
+    elif seconds < 3600:
+        return "{}m {}s".format(int(seconds // 60), int(seconds % 60))
+    else:
+        return "{}h {}m".format(int(seconds // 3600), int((seconds % 3600) // 60))
+
+
+def run_query(endpoint, headers, query, variables):
+    request = requests.post(
+        endpoint,
+        headers=headers,
+        json={'query': query, 'variables': variables}
+    )
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise Exception("Query failed with HTTP {}".format(request.status_code))
 
 
 def get_turbot_identity_id(endpoint, headers):
@@ -36,6 +112,105 @@ def get_turbot_identity_id(endpoint, headers):
     return str(items[0]['turbot']['id'])
 
 
+def get_notification_count(endpoint, headers, base_filter_parts, total_hours):
+    """Get total notification count for the full time range (single API call)."""
+    query = '''
+      query NotificationCount($filter: [String!]) {
+        notifications(filter: $filter) {
+          metadata {
+            stats { total }
+          }
+        }
+      }
+    '''
+    variables = {'filter': base_filter_parts + ["timestamp:>T-{}h".format(total_hours), "limit:1"]}
+    result = run_query(endpoint, headers, query, variables)
+    if "errors" in result:
+        return None
+    return result.get('data', {}).get('notifications', {}).get('metadata', {}).get('stats', {}).get('total')
+
+
+def build_time_windows(total_hours, num_windows):
+    """
+    Split the time range into num_windows equal slices expressed as
+    (hours_ago_start, hours_ago_end) pairs — oldest window first.
+    Uses Turbot's T-Nh relative time notation to avoid ISO timestamp
+    parsing issues in the filter engine.
+
+    Example for total_hours=2160, num_windows=15 (window_size=144h):
+      (2160, 2016), (2016, 1872), ..., (144, 0)
+    The last window (hours_ago_end=0) uses no upper bound in the filter.
+    """
+    window_hours = total_hours / num_windows
+    windows = []
+    for i in range(num_windows):
+        hours_ago_start = round(total_hours - i * window_hours)
+        hours_ago_end   = round(total_hours - (i + 1) * window_hours)
+        windows.append((hours_ago_start, hours_ago_end))
+    return windows
+
+
+def fetch_window(endpoint, headers, base_filter_parts, hours_ago_start, hours_ago_end,
+                 page_size, window_idx, total_windows, progress):
+    """Fetch all notifications for a single time window. Returns list of items.
+
+    hours_ago_start > hours_ago_end (start is further back in time).
+    Uses T-Nh relative time notation: T-2160h means '2160 hours ago'.
+    The newest window (hours_ago_end == 0) has no upper-bound filter,
+    matching the original single-query behaviour.
+    """
+    if hours_ago_end == 0:
+        time_filter = "timestamp:>T-{}h".format(hours_ago_start)
+    else:
+        time_filter = "timestamp:>T-{}h timestamp:<T-{}h".format(hours_ago_start, hours_ago_end)
+    filter_parts = base_filter_parts + [time_filter, "limit:{}".format(page_size)]
+
+    items = []
+    paging = None
+    t_start = time.time()
+
+    while True:
+        variables = {'filter': filter_parts, 'paging': paging}
+        result = run_query(endpoint, headers, NOTIFICATION_QUERY, variables)
+
+        if "errors" in result:
+            for error in result['errors']:
+                tprint("  [Window {}/{}] Error: {}".format(
+                    window_idx, total_windows, error.get('message', error)))
+            break
+
+        data = result['data']['notifications']
+        items.extend(data['items'])
+
+        next_page = data['paging']['next'] if data.get('paging') else None
+        if not next_page:
+            break
+        paging = next_page
+
+    elapsed = time.time() - t_start
+
+    with progress['lock']:
+        progress['windows_done'] += 1
+        progress['items_fetched'] += len(items)
+        done = progress['windows_done']
+        total_items = progress['items_fetched']
+        run_elapsed = time.time() - progress['start_time']
+        # ETA: fraction of windows done → extrapolate total wall time
+        fraction_done = done / total_windows
+        eta_secs = (run_elapsed / fraction_done - run_elapsed) if fraction_done > 0 else 0
+        tprint("  [{:>3}/{}] T-{}h → T-{}h  {:>6} notifications  {:.1f}s  |  total: {:>7,}  ETA: {}".format(
+            done, total_windows,
+            hours_ago_start,
+            hours_ago_end,
+            len(items),
+            elapsed,
+            total_items,
+            fmt_duration(eta_secs) if done < total_windows else "done",
+        ))
+
+    return items
+
+
 @click.command()
 @click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="[String] Pass an optional yaml config file.")
 @click.option('-p', '--profile', default="default", help="[String] Profile to be used from config file.")
@@ -45,13 +220,16 @@ def get_turbot_identity_id(endpoint, headers):
 @click.option('--all-actors', is_flag=True, default=False, help="Include activity from all actors, not just Turbot Identity.")
 @click.option('--csp', default=None, type=click.Choice(['aws', 'azure', 'gcp'], case_sensitive=False), help="[String] Limit to a cloud provider's resources: aws, azure, or gcp. Mutually exclusive with --resource-type.")
 @click.option('--resource-type', default=None, help="[String] Filter by resource type IDs, comma-separated. Takes precedence over --csp. e.g. 'tmod:@turbot/aws#/resource/types/aws,tmod:@turbot/azure#/resource/types/azure'")
-@click.option('--page-size', default=200, type=int, help="[Int] Number of notifications per API request. Default: 200.")
+@click.option('--workers', default=5, type=int, show_default=True, help="[Int] Number of parallel workers. Each worker handles an independent time slice. Default: 5.")
+@click.option('--page-size', default=500, type=int, show_default=True, help="[Int] Number of notifications per API request. Default: 500.")
 @click.option('-o', '--output', default="activity_ledger.csv", help="[String] Output CSV file path. Default: activity_ledger.csv")
-def activity_ledger_export(config_file, profile, days, hours, actor_id, all_actors, csp, resource_type, page_size, output):
+def activity_ledger_export(config_file, profile, days, hours, actor_id, all_actors,
+                           csp, resource_type, workers, page_size, output):
     """Exports Turbot activity (action notifications) for the past N days or hours to a CSV file.
 
     Bypasses the 30-day / 5000-row limits of the Activity Ledger UI by paginating
-    through all results via the GraphQL API.
+    through all results via the GraphQL API. Uses parallel workers to split the time
+    range into independent slices for faster export of large date ranges.
 
     By default, results are filtered to the Turbot Identity actor (automated Turbot
     actions only). Use --all-actors to include actions by human users as well.
@@ -60,14 +238,14 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
     if hours:
         if days != 7:
             raise click.UsageError("--days and --hours are mutually exclusive. Use one or the other.")
-        time_filter = "timestamp:>T-{}h".format(hours)
         window_label = "last {} hours".format(hours)
     else:
-        time_filter = "timestamp:>T-{}d".format(days)
         window_label = "last {} days".format(days)
 
     if actor_id and all_actors:
         raise click.UsageError("--actor-id and --all-actors are mutually exclusive.")
+
+    script_start = time.time()
 
     config = turbot.Config(config_file, profile)
     headers = {'Authorization': 'Basic {}'.format(config.auth_token)}
@@ -84,112 +262,83 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
             else:
                 print("  Warning: Could not resolve Turbot Identity. Falling back to all actors.")
 
-    query = '''
-      query ActivityLedger($filter: [String!], $paging: String) {
-        notifications(filter: $filter, paging: $paging) {
-          metadata {
-            stats {
-              total
-            }
-          }
-          paging {
-            next
-          }
-          items {
-            notificationType
-            message
-            turbot {
-              id
-              processId
-              createTimestamp
-            }
-            actor {
-              identity {
-                title
-              }
-            }
-            resource {
-              trunk {
-                title
-              }
-              turbot {
-                id
-                title
-                akas
-              }
-              type {
-                trunk {
-                  title
-                }
-                uri
-              }
-            }
-          }
-        }
-      }
-    '''
-
-    filter_parts = [
-        "notificationType:action_notify",
-        time_filter,
-        "limit:{}".format(page_size),
-    ]
-
+    # Build the base filter (everything except the time window)
+    base_filter_parts = ["notificationType:action_notify"]
     if resource_type:
         type_ids = [t.strip() for t in resource_type.split(',')]
-        filter_parts.append("resourceTypeId:{}".format(','.join(type_ids)))
+        base_filter_parts.append("resourceTypeId:{}".format(','.join(type_ids)))
     elif csp:
-        filter_parts.append("resourceTypeId:{}".format(CSP_RESOURCE_TYPE_IDS[csp.lower()]))
-
+        base_filter_parts.append("resourceTypeId:{}".format(CSP_RESOURCE_TYPE_IDS[csp.lower()]))
     if actor_id:
-        filter_parts.append("actorIdentityId:'{}'".format(actor_id))
+        base_filter_parts.append("actorIdentityId:'{}'".format(actor_id))
 
-    print("\nFetching Turbot activity for the {}...".format(window_label))
+    # Total time range expressed in whole hours (T-Nh notation)
+    total_hours = (hours if hours else days * 24)
+
+    # Window count: 1 per day (or per hour for --hours mode), capped at workers * 3
+    num_windows = min(max(1, days if not hours else hours), workers * 3)
+    actual_workers = min(workers, num_windows)
+
+    # Get total notification count upfront
+    print("\nCounting notifications for the {}...".format(window_label))
+    total = get_notification_count(endpoint, headers, base_filter_parts, total_hours)
+    if total is not None:
+        print("  Total matching notifications: {:,}".format(total))
+        est_pages = (total + page_size - 1) // page_size
+        est_secs_seq = est_pages * 2  # ~2s per page (conservative)
+        est_secs_par = est_secs_seq / actual_workers
+        print("  Estimated pages              : {:,} (page size {})".format(est_pages, page_size))
+        print("  Estimated time               : {} with {} workers  ({} sequential)".format(
+            fmt_duration(est_secs_par), actual_workers, fmt_duration(est_secs_seq)))
     if actor_id:
-        print("  Actor filter:         {}".format(actor_id))
+        print("  Actor filter                 : {}".format(actor_id))
     elif all_actors:
-        print("  Actor filter:         all actors")
+        print("  Actor filter                 : all actors")
     if resource_type or csp:
-        print("  Resource type filter: {}".format(resource_type or CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+        print("  Resource type filter         : {}".format(resource_type or CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+    print("  Workers                      : {}  |  Windows: {}".format(actual_workers, num_windows))
 
-    items = []
-    paging = None
-    total_reported = False
+    # Build time windows (expressed as hours-ago pairs) and progress tracker
+    windows = build_time_windows(total_hours, num_windows)
+    progress = {
+        'lock': threading.Lock(),
+        'windows_done': 0,
+        'items_fetched': 0,
+        'start_time': time.time(),
+    }
 
-    while True:
-        variables = {'filter': filter_parts, 'paging': paging}
-        result = run_query(endpoint, headers, query, variables)
+    print("\nFetching...\n")
+    all_items = []
 
-        if "errors" in result:
-            for error in result['errors']:
-                print("Error: {}".format(error.get('message', error)))
-            sys.exit(1)
+    with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+        futures = {
+            executor.submit(
+                fetch_window,
+                endpoint, headers, base_filter_parts,
+                hours_ago_start, hours_ago_end, page_size,
+                idx + 1, num_windows, progress
+            ): idx
+            for idx, (hours_ago_start, hours_ago_end) in enumerate(windows)
+        }
+        for future in as_completed(futures):
+            try:
+                all_items.extend(future.result())
+            except Exception as e:
+                tprint("  Window error: {}".format(e))
 
-        data = result['data']['notifications']
+    fetch_elapsed = time.time() - script_start
+    print("\nFetched {:,} notification(s) in {}.".format(len(all_items), fmt_duration(fetch_elapsed)))
 
-        if not total_reported:
-            total = data.get('metadata', {}).get('stats', {}).get('total', 0)
-            print("Total matching notifications: {}\n".format(total))
-            total_reported = True
-
-        batch = data['items']
-        items.extend(batch)
-
-        next_page = data['paging']['next'] if data.get('paging') else None
-        if not next_page:
-            break
-
-        print("  Fetched {} notifications so far...".format(len(items)))
-        paging = next_page
-
-    print("Fetched {} notification(s) total.".format(len(items)))
-
-    if not items:
+    if not all_items:
         print("No activity found for the specified filters.")
         return
 
+    # Sort by timestamp descending (newest first) — parallel fetches may interleave
+    print("Sorting results...")
+    all_items.sort(key=lambda x: x['turbot']['createTimestamp'], reverse=True)
+
     rows = []
-    for item in items:
+    for item in all_items:
         resource = item.get('resource') or {}
         resource_turbot = resource.get('turbot') or {}
         resource_type_data = resource.get('type') or {}
@@ -219,6 +368,7 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
             'detail_link':      detail_link,
         })
 
+    # Print preview table
     preview_cols = ['timestamp', 'actor', 'message', 'resource_aka']
     col_headers = {
         'timestamp':    'Timestamp',
@@ -234,7 +384,7 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
         )
 
     header_line = "  ".join(col_headers[col].ljust(col_widths[col]) for col in preview_cols)
-    separator  = "  ".join("-" * col_widths[col] for col in preview_cols)
+    separator   = "  ".join("-" * col_widths[col] for col in preview_cols)
 
     print("\n{}".format(header_line))
     print(separator)
@@ -262,19 +412,10 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
         for row in rows:
             writer.writerow(row)
 
+    total_elapsed = time.time() - script_start
     print("\nResults written to {}".format(output))
-
-
-def run_query(endpoint, headers, query, variables):
-    request = requests.post(
-        endpoint,
-        headers=headers,
-        json={'query': query, 'variables': variables}
-    )
-    if request.status_code == 200:
-        return request.json()
-    else:
-        raise Exception("Query failed with status {}. {}".format(request.status_code, query))
+    print("Total time: {}  ({:,} notifications, {} workers)".format(
+        fmt_duration(total_elapsed), len(rows), actual_workers))
 
 
 if __name__ == "__main__":

--- a/api_examples/python/activity-ledger-export/activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/activity_ledger_export.py
@@ -1,0 +1,293 @@
+import turbot
+import click
+import csv
+import requests
+import sys
+
+
+CSP_RESOURCE_TYPE_IDS = {
+    'aws':   'tmod:@turbot/aws#/resource/types/aws',
+    'azure': 'tmod:@turbot/azure#/resource/types/azure',
+    'gcp':   'tmod:@turbot/gcp#/resource/types/gcp',
+}
+
+
+def get_turbot_identity_id(endpoint, headers):
+    """Look up the Turbot Identity actor ID for this workspace."""
+    query = '''
+      query GetTurbotIdentity($filter: [String!]) {
+        resources(filter: $filter) {
+          items {
+            turbot {
+              id
+              title
+            }
+          }
+        }
+      }
+    '''
+    variables = {"filter": ["resourceTypeId:'tmod:@turbot/turbot-iam#/resource/types/turbotIdentity' limit:1"]}
+    result = run_query(endpoint, headers, query, variables)
+    if "errors" in result:
+        return None
+    items = result.get('data', {}).get('resources', {}).get('items', [])
+    if not items:
+        return None
+    return str(items[0]['turbot']['id'])
+
+
+@click.command()
+@click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="[String] Pass an optional yaml config file.")
+@click.option('-p', '--profile', default="default", help="[String] Profile to be used from config file.")
+@click.option('--days', default=7, type=int, show_default=True, help="[Int] Fetch activity from the last N days. e.g. 90. Mutually exclusive with --hours.")
+@click.option('--hours', default=None, type=int, help="[Int] Fetch activity from the last N hours. e.g. 24. Mutually exclusive with --days.")
+@click.option('--actor-id', default=None, help="[String] Filter by a specific actor identity ID. Defaults to the Turbot Identity for this workspace.")
+@click.option('--all-actors', is_flag=True, default=False, help="Include activity from all actors, not just Turbot Identity.")
+@click.option('--csp', default=None, type=click.Choice(['aws', 'azure', 'gcp'], case_sensitive=False), help="[String] Limit to a cloud provider's resources: aws, azure, or gcp. Mutually exclusive with --resource-type.")
+@click.option('--resource-type', default=None, help="[String] Filter by resource type IDs, comma-separated. Takes precedence over --csp. e.g. 'tmod:@turbot/aws#/resource/types/aws,tmod:@turbot/azure#/resource/types/azure'")
+@click.option('--page-size', default=200, type=int, help="[Int] Number of notifications per API request. Default: 200.")
+@click.option('-o', '--output', default="activity_ledger.csv", help="[String] Output CSV file path. Default: activity_ledger.csv")
+def activity_ledger_export(config_file, profile, days, hours, actor_id, all_actors, csp, resource_type, page_size, output):
+    """Exports Turbot activity (action notifications) for the past N days or hours to a CSV file.
+
+    Bypasses the 30-day / 5000-row limits of the Activity Ledger UI by paginating
+    through all results via the GraphQL API.
+
+    By default, results are filtered to the Turbot Identity actor (automated Turbot
+    actions only). Use --all-actors to include actions by human users as well.
+    """
+
+    if hours:
+        if days != 7:
+            raise click.UsageError("--days and --hours are mutually exclusive. Use one or the other.")
+        time_filter = "timestamp:>T-{}h".format(hours)
+        window_label = "last {} hours".format(hours)
+    else:
+        time_filter = "timestamp:>T-{}d".format(days)
+        window_label = "last {} days".format(days)
+
+    if actor_id and all_actors:
+        raise click.UsageError("--actor-id and --all-actors are mutually exclusive.")
+
+    config = turbot.Config(config_file, profile)
+    headers = {'Authorization': 'Basic {}'.format(config.auth_token)}
+    endpoint = config.graphql_endpoint
+    workspace_url = config.workspace.rstrip('/')
+
+    # Resolve actor filter: explicit ID > auto-lookup Turbot Identity > all actors
+    if not all_actors:
+        if not actor_id:
+            print("Looking up Turbot Identity actor ID...")
+            actor_id = get_turbot_identity_id(endpoint, headers)
+            if actor_id:
+                print("  Turbot Identity ID: {}".format(actor_id))
+            else:
+                print("  Warning: Could not resolve Turbot Identity. Falling back to all actors.")
+
+    query = '''
+      query ActivityLedger($filter: [String!], $paging: String) {
+        notifications(filter: $filter, paging: $paging) {
+          metadata {
+            stats {
+              total
+            }
+          }
+          paging {
+            next
+          }
+          items {
+            notificationType
+            message
+            turbot {
+              id
+              processId
+              createTimestamp
+            }
+            actor {
+              identity {
+                title
+              }
+            }
+            resource {
+              trunk {
+                title
+              }
+              turbot {
+                id
+                title
+                akas
+              }
+              type {
+                trunk {
+                  title
+                }
+                uri
+              }
+            }
+          }
+        }
+      }
+    '''
+
+    filter_parts = [
+        "notificationType:action_notify",
+        time_filter,
+        "limit:{}".format(page_size),
+    ]
+
+    if resource_type:
+        type_ids = [t.strip() for t in resource_type.split(',')]
+        filter_parts.append("resourceTypeId:{}".format(','.join(type_ids)))
+    elif csp:
+        filter_parts.append("resourceTypeId:{}".format(CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+
+    if actor_id:
+        filter_parts.append("actorIdentityId:'{}'".format(actor_id))
+
+    print("\nFetching Turbot activity for the {}...".format(window_label))
+    if actor_id:
+        print("  Actor filter:         {}".format(actor_id))
+    elif all_actors:
+        print("  Actor filter:         all actors")
+    if resource_type or csp:
+        print("  Resource type filter: {}".format(resource_type or CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+
+    items = []
+    paging = None
+    total_reported = False
+
+    while True:
+        variables = {'filter': filter_parts, 'paging': paging}
+        result = run_query(endpoint, headers, query, variables)
+
+        if "errors" in result:
+            for error in result['errors']:
+                print("Error: {}".format(error.get('message', error)))
+            sys.exit(1)
+
+        data = result['data']['notifications']
+
+        if not total_reported:
+            total = data.get('metadata', {}).get('stats', {}).get('total', 0)
+            print("Total matching notifications: {}\n".format(total))
+            total_reported = True
+
+        batch = data['items']
+        items.extend(batch)
+
+        next_page = data['paging']['next'] if data.get('paging') else None
+        if not next_page:
+            break
+
+        print("  Fetched {} notifications so far...".format(len(items)))
+        paging = next_page
+
+    print("Fetched {} notification(s) total.".format(len(items)))
+
+    if not items:
+        print("No activity found for the specified filters.")
+        return
+
+    rows = []
+    for item in items:
+        resource = item.get('resource') or {}
+        resource_turbot = resource.get('turbot') or {}
+        resource_type_data = resource.get('type') or {}
+        akas = resource_turbot.get('akas') or []
+        resource_trunk = (resource.get('trunk') or {}).get('title') or ''
+        resource_type_trunk = (resource_type_data.get('trunk') or {}).get('title') or ''
+
+        actor = item.get('actor') or {}
+        identity = actor.get('identity') or {}
+        actor_title = identity.get('title') or ''
+
+        notification_id = item['turbot']['id']
+        process_id = item['turbot'].get('processId') or ''
+        detail_link = "{}/apollo/processes/{}/notifications/{}".format(
+            workspace_url, process_id, notification_id
+        ) if process_id else ''
+
+        rows.append({
+            'notification_id':  str(notification_id),
+            'timestamp':        item['turbot']['createTimestamp'],
+            'actor':            actor_title,
+            'message':          item.get('message') or '',
+            'resource_aka':     akas[0] if akas else '',
+            'resource_title':   resource_turbot.get('title', ''),
+            'resource_type':    resource_type_trunk,
+            'resource_trunk':   resource_trunk,
+            'detail_link':      detail_link,
+        })
+
+    preview_cols = ['timestamp', 'actor', 'message', 'resource_aka']
+    col_headers = {
+        'timestamp':    'Timestamp',
+        'actor':        'Actor',
+        'message':      'Message',
+        'resource_aka': 'Resource AKA',
+    }
+    col_widths = {}
+    for col in preview_cols:
+        col_widths[col] = max(
+            len(col_headers[col]),
+            max((len(str(row[col])[:60]) for row in rows), default=0)
+        )
+
+    header_line = "  ".join(col_headers[col].ljust(col_widths[col]) for col in preview_cols)
+    separator  = "  ".join("-" * col_widths[col] for col in preview_cols)
+
+    print("\n{}".format(header_line))
+    print(separator)
+    for row in rows[:50]:
+        line = "  ".join(str(row[col])[:60].ljust(col_widths[col]) for col in preview_cols)
+        print(line)
+    if len(rows) > 50:
+        print("... ({} more rows in CSV)".format(len(rows) - 50))
+
+    csv_columns = [
+        'notification_id',
+        'timestamp',
+        'actor',
+        'message',
+        'resource_aka',
+        'resource_title',
+        'resource_type',
+        'resource_trunk',
+        'detail_link',
+    ]
+
+    with open(output, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+    print("\nResults written to {}".format(output))
+
+
+def run_query(endpoint, headers, query, variables):
+    request = requests.post(
+        endpoint,
+        headers=headers,
+        json={'query': query, 'variables': variables}
+    )
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise Exception("Query failed with status {}. {}".format(request.status_code, query))
+
+
+if __name__ == "__main__":
+    if sys.version_info > (3, 4):
+        try:
+            activity_ledger_export()
+        except Exception as e:
+            print(e)
+    else:
+        print("This script requires Python v3.5+")
+        print("Your Python version is: {}.{}.{}".format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro))
+        if sys.version_info < (3, 0):
+            hint = ["Maybe try: `python3"] + sys.argv
+            hint[len(sys.argv)] = hint[len(sys.argv)] + "`"
+            print(*hint)

--- a/api_examples/python/activity-ledger-export/activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/activity_ledger_export.py
@@ -4,8 +4,6 @@ import csv
 import requests
 import sys
 import time
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 CSP_RESOURCE_TYPE_IDS = {
@@ -16,7 +14,7 @@ CSP_RESOURCE_TYPE_IDS = {
 
 NOTIFICATION_QUERY = '''
   query ActivityLedger($filter: [String!], $paging: String) {
-    notifications(filter: $filter, paging: $paging) {
+    notifications(filter: $filter, paging: $paging, dataSource: DB) {
       metadata {
         stats {
           total
@@ -58,13 +56,6 @@ NOTIFICATION_QUERY = '''
     }
   }
 '''
-
-_print_lock = threading.Lock()
-
-
-def tprint(msg):
-    with _print_lock:
-        print(msg)
 
 
 def fmt_duration(seconds):
@@ -112,105 +103,6 @@ def get_turbot_identity_id(endpoint, headers):
     return str(items[0]['turbot']['id'])
 
 
-def get_notification_count(endpoint, headers, base_filter_parts, total_hours):
-    """Get total notification count for the full time range (single API call)."""
-    query = '''
-      query NotificationCount($filter: [String!]) {
-        notifications(filter: $filter) {
-          metadata {
-            stats { total }
-          }
-        }
-      }
-    '''
-    variables = {'filter': base_filter_parts + ["timestamp:>T-{}h".format(total_hours), "limit:1"]}
-    result = run_query(endpoint, headers, query, variables)
-    if "errors" in result:
-        return None
-    return result.get('data', {}).get('notifications', {}).get('metadata', {}).get('stats', {}).get('total')
-
-
-def build_time_windows(total_hours, num_windows):
-    """
-    Split the time range into num_windows equal slices expressed as
-    (hours_ago_start, hours_ago_end) pairs — oldest window first.
-    Uses Turbot's T-Nh relative time notation to avoid ISO timestamp
-    parsing issues in the filter engine.
-
-    Example for total_hours=2160, num_windows=15 (window_size=144h):
-      (2160, 2016), (2016, 1872), ..., (144, 0)
-    The last window (hours_ago_end=0) uses no upper bound in the filter.
-    """
-    window_hours = total_hours / num_windows
-    windows = []
-    for i in range(num_windows):
-        hours_ago_start = round(total_hours - i * window_hours)
-        hours_ago_end   = round(total_hours - (i + 1) * window_hours)
-        windows.append((hours_ago_start, hours_ago_end))
-    return windows
-
-
-def fetch_window(endpoint, headers, base_filter_parts, hours_ago_start, hours_ago_end,
-                 page_size, window_idx, total_windows, progress):
-    """Fetch all notifications for a single time window. Returns list of items.
-
-    hours_ago_start > hours_ago_end (start is further back in time).
-    Uses T-Nh relative time notation: T-2160h means '2160 hours ago'.
-    The newest window (hours_ago_end == 0) has no upper-bound filter,
-    matching the original single-query behaviour.
-    """
-    if hours_ago_end == 0:
-        time_filter = "timestamp:>=T-{}h".format(hours_ago_start)
-    else:
-        time_filter = "timestamp:>=T-{}h timestamp:<T-{}h".format(hours_ago_start, hours_ago_end)
-    filter_parts = base_filter_parts + [time_filter, "limit:{}".format(page_size)]
-
-    items = []
-    paging = None
-    t_start = time.time()
-
-    while True:
-        variables = {'filter': filter_parts, 'paging': paging}
-        result = run_query(endpoint, headers, NOTIFICATION_QUERY, variables)
-
-        if "errors" in result:
-            for error in result['errors']:
-                tprint("  [Window {}/{}] Error: {}".format(
-                    window_idx, total_windows, error.get('message', error)))
-            break
-
-        data = result['data']['notifications']
-        items.extend(data['items'])
-
-        next_page = data['paging']['next'] if data.get('paging') else None
-        if not next_page:
-            break
-        paging = next_page
-
-    elapsed = time.time() - t_start
-
-    with progress['lock']:
-        progress['windows_done'] += 1
-        progress['items_fetched'] += len(items)
-        done = progress['windows_done']
-        total_items = progress['items_fetched']
-        run_elapsed = time.time() - progress['start_time']
-        # ETA: fraction of windows done → extrapolate total wall time
-        fraction_done = done / total_windows
-        eta_secs = (run_elapsed / fraction_done - run_elapsed) if fraction_done > 0 else 0
-        tprint("  [{:>3}/{}] T-{}h → T-{}h  {:>6} notifications  {:.1f}s  |  total: {:>7,}  ETA: {}".format(
-            done, total_windows,
-            hours_ago_start,
-            hours_ago_end,
-            len(items),
-            elapsed,
-            total_items,
-            fmt_duration(eta_secs) if done < total_windows else "done",
-        ))
-
-    return items
-
-
 @click.command()
 @click.option('-c', '--config-file', type=click.Path(dir_okay=False), help="[String] Pass an optional yaml config file.")
 @click.option('-p', '--profile', default="default", help="[String] Profile to be used from config file.")
@@ -220,16 +112,14 @@ def fetch_window(endpoint, headers, base_filter_parts, hours_ago_start, hours_ag
 @click.option('--all-actors', is_flag=True, default=False, help="Include activity from all actors, not just Turbot Identity.")
 @click.option('--csp', default=None, type=click.Choice(['aws', 'azure', 'gcp'], case_sensitive=False), help="[String] Limit to a cloud provider's resources: aws, azure, or gcp. Mutually exclusive with --resource-type.")
 @click.option('--resource-type', default=None, help="[String] Filter by resource type IDs, comma-separated. Takes precedence over --csp. e.g. 'tmod:@turbot/aws#/resource/types/aws,tmod:@turbot/azure#/resource/types/azure'")
-@click.option('--workers', default=5, type=int, show_default=True, help="[Int] Number of parallel workers. Each worker handles an independent time slice. Default: 5.")
 @click.option('--page-size', default=500, type=int, show_default=True, help="[Int] Number of notifications per API request. Default: 500.")
 @click.option('-o', '--output', default="activity_ledger.csv", help="[String] Output CSV file path. Default: activity_ledger.csv")
 def activity_ledger_export(config_file, profile, days, hours, actor_id, all_actors,
-                           csp, resource_type, workers, page_size, output):
+                           csp, resource_type, page_size, output):
     """Exports Turbot activity (action notifications) for the past N days or hours to a CSV file.
 
     Bypasses the 30-day / 5000-row limits of the Activity Ledger UI by paginating
-    through all results via the GraphQL API. Uses parallel workers to split the time
-    range into independent slices for faster export of large date ranges.
+    through all results via the GraphQL API.
 
     By default, results are filtered to the Turbot Identity actor (automated Turbot
     actions only). Use --all-actors to include actions by human users as well.
@@ -238,8 +128,10 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
     if hours:
         if days != 7:
             raise click.UsageError("--days and --hours are mutually exclusive. Use one or the other.")
+        time_filter = "timestamp:>=T-{}h".format(hours)
         window_label = "last {} hours".format(hours)
     else:
+        time_filter = "timestamp:>=T-{}h".format(days * 24)
         window_label = "last {} days".format(days)
 
     if actor_id and all_actors:
@@ -262,83 +154,85 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
             else:
                 print("  Warning: Could not resolve Turbot Identity. Falling back to all actors.")
 
-    # Build the base filter (everything except the time window)
-    base_filter_parts = ["notificationType:action_notify"]
+    filter_parts = [
+        "notificationType:action_notify",
+        time_filter,
+        "limit:{}".format(page_size),
+    ]
+
     if resource_type:
         type_ids = [t.strip() for t in resource_type.split(',')]
-        base_filter_parts.append("resourceTypeId:{}".format(','.join(type_ids)))
+        filter_parts.append("resourceTypeId:{}".format(','.join(type_ids)))
     elif csp:
-        base_filter_parts.append("resourceTypeId:{}".format(CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+        filter_parts.append("resourceTypeId:{}".format(CSP_RESOURCE_TYPE_IDS[csp.lower()]))
+
     if actor_id:
-        base_filter_parts.append("actorIdentityId:'{}'".format(actor_id))
+        filter_parts.append("actorIdentityId:'{}'".format(actor_id))
 
-    # Total time range expressed in whole hours (T-Nh notation)
-    total_hours = (hours if hours else days * 24)
-
-    # Window count: 1 per day (or per hour for --hours mode), capped at workers * 3
-    num_windows = min(max(1, days if not hours else hours), workers * 3)
-    actual_workers = min(workers, num_windows)
-
-    # Get total notification count upfront
-    print("\nCounting notifications for the {}...".format(window_label))
-    total = get_notification_count(endpoint, headers, base_filter_parts, total_hours)
-    if total is not None:
-        print("  Total matching notifications: {:,}".format(total))
-        est_pages = (total + page_size - 1) // page_size
-        est_secs_seq = est_pages * 2  # ~2s per page (conservative)
-        est_secs_par = est_secs_seq / actual_workers
-        print("  Estimated pages              : {:,} (page size {})".format(est_pages, page_size))
-        print("  Estimated time               : {} with {} workers  ({} sequential)".format(
-            fmt_duration(est_secs_par), actual_workers, fmt_duration(est_secs_seq)))
+    print("\nFetching Turbot activity for the {}...".format(window_label))
     if actor_id:
-        print("  Actor filter                 : {}".format(actor_id))
+        print("  Actor filter         : {}".format(actor_id))
     elif all_actors:
-        print("  Actor filter                 : all actors")
+        print("  Actor filter         : all actors")
     if resource_type or csp:
-        print("  Resource type filter         : {}".format(resource_type or CSP_RESOURCE_TYPE_IDS[csp.lower()]))
-    print("  Workers                      : {}  |  Windows: {}".format(actual_workers, num_windows))
+        print("  Resource type filter : {}".format(resource_type or CSP_RESOURCE_TYPE_IDS[csp.lower()]))
 
-    # Build time windows (expressed as hours-ago pairs) and progress tracker
-    windows = build_time_windows(total_hours, num_windows)
-    progress = {
-        'lock': threading.Lock(),
-        'windows_done': 0,
-        'items_fetched': 0,
-        'start_time': time.time(),
-    }
+    items = []
+    paging = None
+    total_reported = None
+    fetch_start = time.time()
 
-    print("\nFetching...\n")
-    all_items = []
+    while True:
+        variables = {'filter': filter_parts, 'paging': paging}
+        result = run_query(endpoint, headers, NOTIFICATION_QUERY, variables)
 
-    with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-        futures = {
-            executor.submit(
-                fetch_window,
-                endpoint, headers, base_filter_parts,
-                hours_ago_start, hours_ago_end, page_size,
-                idx + 1, num_windows, progress
-            ): idx
-            for idx, (hours_ago_start, hours_ago_end) in enumerate(windows)
-        }
-        for future in as_completed(futures):
-            try:
-                all_items.extend(future.result())
-            except Exception as e:
-                tprint("  Window error: {}".format(e))
+        if "errors" in result:
+            for error in result['errors']:
+                print("Error: {}".format(error.get('message', error)))
+            sys.exit(1)
 
-    fetch_elapsed = time.time() - script_start
-    print("\nFetched {:,} notification(s) in {}.".format(len(all_items), fmt_duration(fetch_elapsed)))
+        data = result['data']['notifications']
 
-    if not all_items:
+        if total_reported is None:
+            total_reported = data.get('metadata', {}).get('stats', {}).get('total', 0)
+            print("  Total notifications  : {:,}\n".format(total_reported))
+
+        batch = data['items']
+        items.extend(batch)
+
+        elapsed = time.time() - fetch_start
+        rate = len(items) / elapsed if elapsed > 0 else 0
+        eta = ((total_reported - len(items)) / rate) if rate > 0 and total_reported > len(items) else 0
+        print("  Fetched {:>8,} / {:>8,}  |  {:.0f}/s  |  elapsed: {}  |  ETA: {}".format(
+            len(items), total_reported,
+            rate,
+            fmt_duration(elapsed),
+            fmt_duration(eta) if eta > 0 else "done"
+        ))
+
+        next_page = data['paging']['next'] if data.get('paging') else None
+        if not next_page:
+            break
+        paging = next_page
+
+    fetch_elapsed = time.time() - fetch_start
+    print("\nFetched {:,} notification(s) in {}.".format(len(items), fmt_duration(fetch_elapsed)))
+
+    if total_reported and len(items) < total_reported * 0.95:
+        print("  Note: {:,} of {:,} total notifications were returned by the API.".format(
+            len(items), total_reported))
+        print("  This may reflect an API cache limit for short time windows. For complete")
+        print("  results, use a longer time range (--days 30 or more).")
+
+    if not items:
         print("No activity found for the specified filters.")
         return
 
-    # Sort by timestamp descending (newest first) — parallel fetches may interleave
     print("Sorting results...")
-    all_items.sort(key=lambda x: x['turbot']['createTimestamp'], reverse=True)
+    items.sort(key=lambda x: x['turbot']['createTimestamp'], reverse=True)
 
     rows = []
-    for item in all_items:
+    for item in items:
         resource = item.get('resource') or {}
         resource_turbot = resource.get('turbot') or {}
         resource_type_data = resource.get('type') or {}
@@ -414,8 +308,7 @@ def activity_ledger_export(config_file, profile, days, hours, actor_id, all_acto
 
     total_elapsed = time.time() - script_start
     print("\nResults written to {}".format(output))
-    print("Total time: {}  ({:,} notifications, {} workers)".format(
-        fmt_duration(total_elapsed), len(rows), actual_workers))
+    print("Total time: {}  ({:,} notifications)".format(fmt_duration(total_elapsed), len(rows)))
 
 
 if __name__ == "__main__":

--- a/api_examples/python/activity-ledger-export/requirements.txt
+++ b/api_examples/python/activity-ledger-export/requirements.txt
@@ -1,0 +1,4 @@
+Click>=8.1.6
+requests>=2.31.0
+xdg>=6.0.0
+PyYAML>=6.0.1

--- a/api_examples/python/activity-ledger-export/test_activity_ledger_export.py
+++ b/api_examples/python/activity-ledger-export/test_activity_ledger_export.py
@@ -1,0 +1,485 @@
+"""
+Unit tests for activity_ledger_export.py.
+
+Covers pure functions and network-dependent functions via mocking.
+Run with: pytest test_activity_ledger_export.py
+"""
+import threading
+import time
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import requests
+
+import activity_ledger_export as ale
+
+
+# ---------------------------------------------------------------------------
+# fmt_duration
+# ---------------------------------------------------------------------------
+
+class TestFmtDuration:
+    def test_seconds_only(self):
+        assert ale.fmt_duration(0) == "0s"
+        assert ale.fmt_duration(1) == "1s"
+        assert ale.fmt_duration(59) == "59s"
+
+    def test_minutes_and_seconds(self):
+        assert ale.fmt_duration(60) == "1m 0s"
+        assert ale.fmt_duration(90) == "1m 30s"
+        assert ale.fmt_duration(3599) == "59m 59s"
+
+    def test_hours_and_minutes(self):
+        assert ale.fmt_duration(3600) == "1h 0m"
+        assert ale.fmt_duration(3661) == "1h 1m"
+        assert ale.fmt_duration(7322) == "2h 2m"
+
+
+# ---------------------------------------------------------------------------
+# build_date_chunks
+# ---------------------------------------------------------------------------
+
+class TestBuildDateChunks:
+    def test_single_chunk_fits_range(self):
+        chunks = ale.build_date_chunks("2026-01-01", "2026-01-07", 7)
+        assert chunks == [("2026-01-01", "2026-01-08")]
+
+    def test_exact_multiple_of_chunk_days(self):
+        chunks = ale.build_date_chunks("2026-01-01", "2026-01-14", 7)
+        assert chunks == [
+            ("2026-01-01", "2026-01-08"),
+            ("2026-01-08", "2026-01-15"),
+        ]
+
+    def test_partial_last_chunk(self):
+        chunks = ale.build_date_chunks("2026-01-01", "2026-01-10", 7)
+        assert chunks == [
+            ("2026-01-01", "2026-01-08"),
+            ("2026-01-08", "2026-01-11"),
+        ]
+
+    def test_single_day(self):
+        chunks = ale.build_date_chunks("2026-03-15", "2026-03-15", 1)
+        assert chunks == [("2026-03-15", "2026-03-16")]
+
+    def test_chunk_larger_than_range(self):
+        chunks = ale.build_date_chunks("2026-05-01", "2026-05-03", 30)
+        assert chunks == [("2026-05-01", "2026-05-04")]
+
+    def test_chunk_start_equals_end(self):
+        # to_date exclusive boundary: chunk_to is end + 1 day
+        chunks = ale.build_date_chunks("2026-06-01", "2026-06-01", 7)
+        assert len(chunks) == 1
+        assert chunks[0][0] == "2026-06-01"
+
+
+# ---------------------------------------------------------------------------
+# item_to_row
+# ---------------------------------------------------------------------------
+
+def _make_item(**overrides):
+    base = {
+        "notificationType": "action_notify",
+        "message": "Resource updated",
+        "turbot": {
+            "id": "12345",
+            "processId": "99999",
+            "createTimestamp": "2026-06-01T12:00:00.000Z",
+        },
+        "actor": {
+            "identity": {"title": "Turbot Identity"}
+        },
+        "resource": {
+            "trunk": {"title": "Root > MyAccount"},
+            "turbot": {
+                "id": "67890",
+                "title": "MyBucket",
+                "akas": ["arn:aws:s3:::mybucket"],
+            },
+            "type": {
+                "trunk": {"title": "AWS > S3 > Bucket"},
+                "uri": "tmod:@turbot/aws-s3#/resource/types/bucket",
+            },
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+class TestItemToRow:
+    WS = "https://example.turbot.com"
+
+    def test_full_item(self):
+        row = ale.item_to_row(_make_item(), self.WS)
+        assert row["notification_id"] == "12345"
+        assert row["notification_type"] == "action_notify"
+        assert row["timestamp"] == "2026-06-01T12:00:00.000Z"
+        assert row["actor"] == "Turbot Identity"
+        assert row["message"] == "Resource updated"
+        assert row["resource_aka"] == "arn:aws:s3:::mybucket"
+        assert row["resource_title"] == "MyBucket"
+        assert row["resource_type"] == "AWS > S3 > Bucket"
+        assert row["resource_trunk"] == "Root > MyAccount"
+        assert row["detail_link"] == (
+            "https://example.turbot.com/apollo/processes/99999/notifications/12345"
+        )
+
+    def test_detail_link_absent_when_no_process_id(self):
+        item = _make_item()
+        item["turbot"]["processId"] = ""
+        row = ale.item_to_row(item, self.WS)
+        assert row["detail_link"] == ""
+
+    def test_empty_akas_uses_empty_string(self):
+        item = _make_item()
+        item["resource"]["turbot"]["akas"] = []
+        row = ale.item_to_row(item, self.WS)
+        assert row["resource_aka"] == ""
+
+    def test_null_resource(self):
+        item = _make_item()
+        item["resource"] = None
+        row = ale.item_to_row(item, self.WS)
+        assert row["resource_aka"] == ""
+        assert row["resource_title"] == ""
+        assert row["resource_type"] == ""
+        assert row["resource_trunk"] == ""
+
+    def test_null_actor(self):
+        item = _make_item()
+        item["actor"] = None
+        row = ale.item_to_row(item, self.WS)
+        assert row["actor"] == ""
+
+    def test_workspace_url_trailing_slash_not_normalized(self):
+        # item_to_row does not rstrip workspace_url — the CLI caller handles that.
+        # A trailing slash produces a double-slash in the detail_link.
+        item = _make_item()
+        row = ale.item_to_row(item, "https://example.turbot.com/")
+        assert row["detail_link"].startswith("https://example.turbot.com//apollo/")
+
+    def test_notification_id_coerced_to_string(self):
+        item = _make_item()
+        item["turbot"]["id"] = 12345  # int, not string
+        row = ale.item_to_row(item, self.WS)
+        assert row["notification_id"] == "12345"
+        assert isinstance(row["notification_id"], str)
+
+    def test_null_turbot_field_does_not_crash(self):
+        # regression: bare item['turbot']['createTimestamp'] would raise TypeError
+        item = _make_item()
+        item["turbot"] = None
+        row = ale.item_to_row(item, self.WS)
+        assert row["notification_id"] == ""
+        assert row["timestamp"] == ""
+        assert row["detail_link"] == ""
+
+
+# ---------------------------------------------------------------------------
+# run_query — retry and success paths
+# ---------------------------------------------------------------------------
+
+def _mock_response(status_code, json_body=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body or {}
+    return resp
+
+
+class TestRunQuery:
+    ENDPOINT = "https://example.turbot.com/api/latest/graphql"
+    HEADERS = {"Authorization": "Basic abc123"}
+    QUERY = "query { __typename }"
+    VARS = {}
+
+    def test_success_on_first_attempt(self):
+        payload = {"data": {"notifications": {}}}
+        with patch("requests.post", return_value=_mock_response(200, payload)) as mock_post:
+            result = ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS)
+        assert result == payload
+        mock_post.assert_called_once()
+
+    def test_retries_on_429_then_succeeds(self):
+        payload = {"data": {}}
+        responses = [_mock_response(429), _mock_response(200, payload)]
+        with patch("requests.post", side_effect=responses):
+            with patch("time.sleep"):
+                result = ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS,
+                                       max_retries=3)
+        assert result == payload
+
+    def test_retries_on_503(self):
+        payload = {"data": {}}
+        responses = [_mock_response(503), _mock_response(503), _mock_response(200, payload)]
+        with patch("requests.post", side_effect=responses):
+            with patch("time.sleep"):
+                result = ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS,
+                                       max_retries=5)
+        assert result == payload
+
+    def test_raises_on_non_retriable_http_error(self):
+        with patch("requests.post", return_value=_mock_response(400)):
+            with pytest.raises(Exception, match="HTTP 400"):
+                ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS, max_retries=3)
+
+    def test_raises_after_exhausting_retries(self):
+        with patch("requests.post", return_value=_mock_response(503)):
+            with patch("time.sleep"):
+                with pytest.raises(Exception, match="after 3 retries"):
+                    ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS, max_retries=3)
+
+    def test_retries_on_timeout_exception(self):
+        payload = {"data": {}}
+        side_effects = [
+            requests.exceptions.Timeout("timed out"),
+            _mock_response(200, payload),
+        ]
+        with patch("requests.post", side_effect=side_effects):
+            with patch("time.sleep"):
+                result = ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS,
+                                       max_retries=3)
+        assert result == payload
+
+    def test_raises_after_exhausting_timeout_retries(self):
+        with patch("requests.post", side_effect=requests.exceptions.Timeout("timed out")):
+            with patch("time.sleep"):
+                with pytest.raises(Exception, match="after 2 retries"):
+                    ale.run_query(self.ENDPOINT, self.HEADERS, self.QUERY, self.VARS, max_retries=2)
+
+
+# ---------------------------------------------------------------------------
+# get_turbot_identity_id
+# ---------------------------------------------------------------------------
+
+class TestGetTurbotIdentityId:
+    ENDPOINT = "https://example.turbot.com/api/latest/graphql"
+    HEADERS = {}
+
+    def test_returns_id_when_found(self):
+        payload = {"data": {"resources": {"items": [{"turbot": {"id": 777, "title": "turbot"}}]}}}
+        with patch.object(ale, "run_query", return_value=payload):
+            result = ale.get_turbot_identity_id(self.ENDPOINT, self.HEADERS)
+        assert result == "777"
+
+    def test_returns_none_when_no_items(self):
+        payload = {"data": {"resources": {"items": []}}}
+        with patch.object(ale, "run_query", return_value=payload):
+            result = ale.get_turbot_identity_id(self.ENDPOINT, self.HEADERS)
+        assert result is None
+
+    def test_returns_none_on_graphql_errors(self):
+        payload = {"errors": [{"message": "Unauthorized"}]}
+        with patch.object(ale, "run_query", return_value=payload):
+            result = ale.get_turbot_identity_id(self.ENDPOINT, self.HEADERS)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _paginate — streaming and accumulating modes
+# ---------------------------------------------------------------------------
+
+def _make_progress(key="types_done"):
+    total_key = "total_" + key.replace("_done", "")
+    return {
+        "lock": threading.Lock(),
+        key: 0,
+        "items_fetched": 0,
+        total_key: 1,
+        "start_time": time.time(),
+    }
+
+
+def _make_notification_payload(items, next_cursor=None):
+    return {
+        "data": {
+            "notifications": {
+                "metadata": {"stats": {"total": len(items)}},
+                "paging": {"next": next_cursor},
+                "items": items,
+            }
+        }
+    }
+
+
+class TestPaginate:
+    ENDPOINT = "https://example.turbot.com/api/latest/graphql"
+    HEADERS = {}
+    FILTER = ["notificationType:action_notify"]
+
+    def test_single_page_accumulate(self):
+        items = [_make_item(), _make_item()]
+        payload = _make_notification_payload(items, next_cursor=None)
+        progress = _make_progress()
+
+        with patch.object(ale, "run_query", return_value=payload):
+            result = ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                                   "test", 500, progress, "types_done")
+
+        assert len(result) == 2
+
+    def test_multi_page_accumulate(self):
+        items_p1 = [_make_item()]
+        items_p2 = [_make_item(), _make_item()]
+        payloads = [
+            _make_notification_payload(items_p1, next_cursor="cursor-abc"),
+            _make_notification_payload(items_p2, next_cursor=None),
+        ]
+        progress = _make_progress()
+
+        with patch.object(ale, "run_query", side_effect=payloads):
+            result = ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                                   "test", 500, progress, "types_done")
+
+        assert len(result) == 3
+
+    def test_streaming_write_fn_called_per_page(self):
+        items_p1 = [_make_item()]
+        items_p2 = [_make_item()]
+        payloads = [
+            _make_notification_payload(items_p1, next_cursor="cursor-abc"),
+            _make_notification_payload(items_p2, next_cursor=None),
+        ]
+        progress = _make_progress()
+        collected = []
+
+        with patch.object(ale, "run_query", side_effect=payloads):
+            result = ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                                   "test", 500, progress, "types_done",
+                                   write_fn=lambda page: collected.extend(page))
+
+        assert result == []  # write_fn mode returns empty list
+        assert len(collected) == 2
+
+    def test_query_error_stops_pagination(self):
+        payload = {"errors": [{"message": "server error"}]}
+        progress = _make_progress()
+
+        with patch.object(ale, "run_query", return_value=payload):
+            result = ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                                   "test", 500, progress, "types_done")
+
+        assert result == []
+
+    def test_query_error_on_page2_returns_partial_and_reports_count(self):
+        # regression: error on page 2 should report items fetched so far, not silently return 0
+        items_p1 = [_make_item(), _make_item()]
+        payloads = [
+            _make_notification_payload(items_p1, next_cursor="cursor-abc"),
+            {"errors": [{"message": "timeout"}]},
+        ]
+        progress = _make_progress()
+
+        with patch.object(ale, "run_query", side_effect=payloads):
+            with patch("activity_ledger_export.tprint") as mock_tprint:
+                result = ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                                       "test", 500, progress, "types_done")
+
+        assert len(result) == 2  # partial results from page 1 returned
+        error_messages = " ".join(str(c) for c in mock_tprint.call_args_list)
+        assert "2" in error_messages  # item count mentioned in the stop message
+
+    def test_exception_stops_pagination(self):
+        progress = _make_progress()
+
+        with patch.object(ale, "run_query", side_effect=Exception("network error")):
+            result = ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                                   "test", 500, progress, "types_done")
+
+        assert result == []
+
+    def test_progress_counter_incremented(self):
+        items = [_make_item()]
+        payload = _make_notification_payload(items)
+        progress = _make_progress()
+
+        with patch.object(ale, "run_query", return_value=payload):
+            ale._paginate(self.ENDPOINT, self.HEADERS, self.FILTER,
+                          "test", 500, progress, "types_done")
+
+        assert progress["types_done"] == 1
+        assert progress["items_fetched"] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_chunk — empty resource_type_ids (single unfiltered worker)
+# ---------------------------------------------------------------------------
+
+class TestRunChunkNoResourceTypes:
+    ENDPOINT = "https://example.turbot.com/api/latest/graphql"
+    HEADERS = {}
+
+    def test_empty_resource_type_ids_uses_single_worker(self):
+        items = [_make_item(), _make_item()]
+        payload = _make_notification_payload(items)
+
+        with patch.object(ale, "run_query", return_value=payload):
+            result = ale.run_chunk(
+                self.ENDPOINT, self.HEADERS,
+                ["notificationType:action_notify"],
+                [],  # no resource_type_ids
+                "2026-06-01", "2026-06-08",
+                500, 7,
+                "2026-06-01 → 2026-06-08", 1, 1,
+                all_notifications=False,
+            )
+
+        assert len(result) == 2
+
+    def test_empty_resource_type_ids_filter_has_no_resourceTypeId(self):
+        captured = []
+
+        def capture_call(endpoint, headers, query, variables, **kwargs):
+            captured.append(variables["filter"])
+            return _make_notification_payload([])
+
+        with patch.object(ale, "run_query", side_effect=capture_call):
+            ale.run_chunk(
+                self.ENDPOINT, self.HEADERS,
+                ["notificationType:action_notify"],
+                [],
+                "2026-06-01", "2026-06-08",
+                500, 7,
+                "label", 1, 1,
+                all_notifications=False,
+            )
+
+        assert captured, "run_query was not called"
+        filter_sent = captured[0]
+        assert not any("resourceTypeId" in f for f in filter_sent)
+
+
+# ---------------------------------------------------------------------------
+# --resume guard: output exists but no checkpoint
+# ---------------------------------------------------------------------------
+
+class TestResumeGuard:
+    def test_resume_rejected_when_output_exists_but_no_checkpoint(self, tmp_path):
+        from click.testing import CliRunner
+        output_file = tmp_path / "out.csv"
+        output_file.write_text("notification_id\n")  # simulate existing output
+
+        runner = CliRunner()
+        result = runner.invoke(ale.activity_ledger_export, [
+            "--from-date", "2026-06-01",
+            "--to-date", "2026-06-07",
+            "--resume",
+            "--output", str(output_file),
+        ])
+
+        assert result.exit_code != 0
+        assert "checkpoint" in result.output.lower()
+
+    def test_resume_rejected_when_neither_file_exists(self, tmp_path):
+        from click.testing import CliRunner
+        output_file = tmp_path / "nonexistent.csv"
+
+        runner = CliRunner()
+        result = runner.invoke(ale.activity_ledger_export, [
+            "--from-date", "2026-06-01",
+            "--to-date", "2026-06-07",
+            "--resume",
+            "--output", str(output_file),
+        ])
+
+        assert result.exit_code != 0
+        assert "checkpoint" in result.output.lower() or "no checkpoint" in result.output.lower()

--- a/api_examples/python/activity-ledger-export/turbot.py
+++ b/api_examples/python/activity-ledger-export/turbot.py
@@ -1,0 +1,111 @@
+import os
+from base64 import b64encode
+from xdg import XDG_CONFIG_HOME
+import yaml
+import requests
+
+
+class Config:
+    """ Locates the users Turbot credentials, verifies connectivity to
+        the specified Turbot workspace and instantiates a config object. """
+
+    def __init__(self, custom_config_file, config_profile):
+
+        config_dict = {}
+        config_fail = ""
+        turbot_config = "{}/turbot/credentials.yml".format(XDG_CONFIG_HOME)
+        graphql_path = 'api/latest/graphql'
+        health_path = 'api/latest/turbot/health'
+
+        # Option 1: Use custom yaml configuration file.
+        if custom_config_file:
+            with open(custom_config_file, 'r') as stream:
+                try:
+                    config_dict = yaml.safe_load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
+
+        # Option 2: Use environment variables
+        elif (os.getenv("TURBOT_ACCESS_KEY_ID") and os.getenv("TURBOT_SECRET_ACCESS_KEY")):
+            config_dict[config_profile] = {}
+            config_dict[config_profile]['accessKey'] = os.getenv(
+                "TURBOT_ACCESS_KEY_ID")
+            config_dict[config_profile]['secretKey'] = os.getenv(
+                "TURBOT_SECRET_ACCESS_KEY")
+
+            # Option 2a: Use TURBOT_WORKSPACE environment variable
+            if os.getenv("TURBOT_WORKSPACE"):
+                config_dict[config_profile]['workspace'] = os.getenv(
+                    "TURBOT_WORKSPACE")
+
+            # Option 2b: Use TURBOT_GRAPHQL_ENDPOINT environment variable
+            elif os.getenv("TURBOT_GRAPHQL_ENDPOINT"):
+                if os.getenv("TURBOT_GRAPHQL_ENDPOINT").endswith(graphql_path):
+                    config_dict[config_profile]['workspace'] = os.getenv(
+                        "TURBOT_GRAPHQL_ENDPOINT")[:-len(graphql_path)]
+                else:
+                    config_fail = "Incorrect TURBOT_GRAPHQL_ENDPOINT format, exiting..."
+            else:
+                config_fail = "No workspace found in environment vars, exiting..."
+
+        # Option 3: Use Turbot xdg configuration file (e.g. ~/.config/turbot/configuration.yml)
+        elif os.path.exists(turbot_config):
+            with open(turbot_config, 'r') as stream:
+                try:
+                    config_dict = yaml.safe_load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
+
+        if len(config_fail):
+            print(config_fail)
+            exit()
+
+        if config_dict:
+
+            if not config_profile in config_dict:
+                config_fail = "No matching profile, exiting..."
+
+            if not all(k in config_dict[config_profile] for k in ("workspace", "accessKey", "secretKey")):
+                config_fail = "Incorrect config file format, exiting..."
+
+            if len(config_fail):
+                print(config_fail)
+                exit()
+
+            self.workspace = config_dict[config_profile]['workspace']
+            self.accessKey = config_dict[config_profile]['accessKey']
+            self.secretKey = config_dict[config_profile]['secretKey']
+            # Set and Test Endpoints
+            if self.workspace.endswith("/"):
+                self.graphql_endpoint = "{}{}".format(
+                    self.workspace, graphql_path)
+                self.health_endpoint = "{}{}".format(
+                    self.workspace, health_path)
+            else:
+                self.graphql_endpoint = "{}/{}".format(
+                    self.workspace, graphql_path)
+                self.health_endpoint = "{}/{}".format(
+                    self.workspace, health_path)
+
+            print("Testing connection to {} ...".format(self.workspace))
+            self.test_health()
+            auth_bytes = '{}:{}'.format(
+                self.accessKey, self.secretKey).encode("utf-8")
+            self.auth_token = b64encode(auth_bytes).decode()
+
+        else:
+            print("Failed to find suitable configuration, please see README")
+            exit()
+
+    def test_health(self):
+        try:
+            r = requests.get(self.health_endpoint)
+        except requests.exceptions.ConnectionError:
+            print("Failed to connect, exiting.")
+            exit()
+
+        if r.status_code == requests.codes.ok:
+            print("Success! Status Code: {}".format(r.status_code))
+        else:
+            print("Failure! Status Code: {}".format(r.status_code))
+            r.raise_for_status()


### PR DESCRIPTION
## Summary

- Adds `api_examples/python/activity-ledger-export/` — a Python script that exports Turbot notifications to CSV, bypassing the 30-day / 5,000-row limits of the Guardrails UI
- Paginates the GraphQL API with parallel workers, chunked date windows, streaming writes (no memory accumulation), and checkpoint/resume support
- Two modes: **action_notify only** (Activity Ledger default) and **all notification types** (`--all-notifications`)
- Auto-resolves the Turbot Identity actor ID at startup; no manual configuration needed for the default use case

## Bug fixes included

- **Crash on null `turbot` field**: bare subscript on `item['turbot']['createTimestamp']` replaced with safe `turbot_data.get()`
- **Silent row duplication on `--resume`**: if output exists but checkpoint is missing, now raises an error instead of appending duplicate rows
- **CSV file handle leak**: chunk loop wrapped in `try/finally` so handle is always closed on interrupt or error
- **Spurious `resourceTypeId` filter**: without `--csp`, no longer injects a `resourceTypeId` per CSP type — runs as a single unfiltered worker instead
- **Version guard**: `> (3, 4)` corrected to `>= (3, 5)`
- **GraphQL error logging**: mid-pagination errors now report partial item count, not just the error message

## Tests

38 tests covering all core functions and the bug fixes above:
```shell
pytest test_activity_ledger_export.py
```

## Test plan

- [ ] `python3 activity_ledger_export.py --days 90` — auto-resolves Turbot Identity, chunks into 7-day windows, streams to CSV
- [ ] `python3 activity_ledger_export.py --from-date 2026-01-01 --to-date 2026-03-31` — explicit date range
- [ ] `python3 activity_ledger_export.py --days 90 --csp aws --csp azure` — multi-platform filter
- [ ] `python3 activity_ledger_export.py --hours 24` — short relative window (in-memory mode with preview)
- [ ] `python3 activity_ledger_export.py --all-notifications --days 7 --all-actors` — all notification types
- [ ] Interrupt mid-run, verify checkpoint file written; re-run with `--resume`, verify no duplicate rows
- [ ] Verify `--resume` errors when output exists but checkpoint is missing
- [ ] Verify CSV row count matches paginated total (not `metadata.stats.total`, which is unreliable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)