### PR TITLE
Add AI policy packs for Bedrock, AI Foundry, Vertex AI, Anthropic, OpenAI

### DIFF
--- a/policy_packs/anthropic/enforce_allowed_email_domains_for_users/README.md
+++ b/policy_packs/anthropic/enforce_allowed_email_domains_for_users/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "access management"]
+primary_category: "ai"
+---
+
+# Enforce Allowed Email Domains for Anthropic Users
+
+[Anthropic organization users](https://docs.anthropic.com/en/api/admin-api/users/get-user) are identified by their email address. Restricting membership to an approved set of email domains ensures that only trusted identities, such as your corporate domain, can be part of the organization. This reduces the risk of unauthorized or personal accounts gaining access to your Anthropic resources.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Anthropic users:
+
+- Check or enforce that users belong to an approved email domain
+- Specify the list of allowed email domain patterns, including wildcards
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/anthropic_enforce_allowed_email_domains_for_users/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/anthropic](https://hub.guardrails.turbot.com/mods/anthropic/mods/anthropic)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/anthropic/enforce_allowed_email_domains_for_users
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "anthropic_user_allowed_email_domain" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/userAllowedEmailDomain"
+  # value    = "Check: Allowed"
+  value    = "Enforce: Delete if domain not allowed"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/anthropic/enforce_allowed_email_domains_for_users/main.tf
+++ b/policy_packs/anthropic/enforce_allowed_email_domains_for_users/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Allowed Email Domains for Anthropic Users"
+  description = "Restrict Anthropic organization membership to trusted identities by requiring user email addresses to match an approved set of domains."
+  akas        = ["anthropic_enforce_allowed_email_domains_for_users"]
+}

--- a/policy_packs/anthropic/enforce_allowed_email_domains_for_users/policies.tf
+++ b/policy_packs/anthropic/enforce_allowed_email_domains_for_users/policies.tf
@@ -1,0 +1,17 @@
+# Anthropic > User > Allowed > Email Domain
+resource "turbot_policy_setting" "anthropic_user_allowed_email_domain" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/userAllowedEmailDomain"
+  value    = "Check: Allowed"
+  # value    = "Enforce: Delete if domain not allowed"
+}
+
+# Anthropic > User > Allowed > Email Domain > Domains
+resource "turbot_policy_setting" "anthropic_user_allowed_email_domain_domains" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/userAllowedEmailDomainDomains"
+  value    = <<-EOT
+    - "turbot.com"
+    - "*.turbot.com"
+    EOT
+}

--- a/policy_packs/anthropic/enforce_allowed_email_domains_for_users/providers.tf
+++ b/policy_packs/anthropic/enforce_allowed_email_domains_for_users/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/anthropic/enforce_api_key_rotation/README.md
+++ b/policy_packs/anthropic/enforce_api_key_rotation/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "access management", "security"]
+primary_category: "ai"
+---
+
+# Enforce API Key Rotation for Anthropic
+
+[Anthropic API keys](https://docs.anthropic.com/en/api/admin-api/apikeys/get-api-key) authenticate requests to the Anthropic API. Long-lived keys that are never rotated increase the blast radius of a leaked credential. By treating keys older than a set age as inactive, you can surface stale keys and, with enforcement enabled, automatically disable them so that credentials are rotated on a predictable schedule.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Anthropic API keys:
+
+- Check or enforce that API keys are active based on their age
+- Treat keys older than a set number of days as inactive
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/anthropic_enforce_api_key_rotation/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/anthropic](https://hub.guardrails.turbot.com/mods/anthropic/mods/anthropic)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/anthropic/enforce_api_key_rotation
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "anthropic_api_key_active" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/apiKeyActive"
+  # value    = "Check: Active"
+  value    = "Enforce: Disable inactive with 90 days warning"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/anthropic/enforce_api_key_rotation/main.tf
+++ b/policy_packs/anthropic/enforce_api_key_rotation/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce API Key Rotation for Anthropic"
+  description = "Reduce the blast radius of leaked credentials by requiring Anthropic API keys to be rotated, treating keys older than a set age as inactive."
+  akas        = ["anthropic_enforce_api_key_rotation"]
+}

--- a/policy_packs/anthropic/enforce_api_key_rotation/policies.tf
+++ b/policy_packs/anthropic/enforce_api_key_rotation/policies.tf
@@ -1,0 +1,14 @@
+# Anthropic > API Key > Active
+resource "turbot_policy_setting" "anthropic_api_key_active" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/apiKeyActive"
+  value    = "Check: Active"
+  # value    = "Enforce: Disable inactive with 90 days warning"
+}
+
+# Anthropic > API Key > Active > Age
+resource "turbot_policy_setting" "anthropic_api_key_active_age" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/apiKeyActiveAge"
+  value    = "Force inactive if age > 90 days"
+}

--- a/policy_packs/anthropic/enforce_api_key_rotation/providers.tf
+++ b/policy_packs/anthropic/enforce_api_key_rotation/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/anthropic/enforce_data_residency_for_workspaces/README.md
+++ b/policy_packs/anthropic/enforce_data_residency_for_workspaces/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["ai", "data protection", "compliance"]
+primary_category: "ai"
+---
+
+# Enforce Data Residency for Anthropic Workspaces
+
+[Anthropic data residency](https://docs.anthropic.com/en/build-with-claude/data-residency) controls which geographies a workspace's model inference runs in. By configuring a workspace's `allowed_inference_geos` and `default_inference_geo`, you ensure that prompts and responses are processed only within approved regions, which is essential for meeting data sovereignty, privacy, and regulatory requirements.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Anthropic workspaces:
+
+- Check or enforce that data residency is enabled on each workspace
+- Specify the set of inference geos that requests are permitted to use
+- Specify the default inference geo applied when a request does not specify one
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/anthropic_enforce_data_residency_for_workspaces/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/anthropic](https://hub.guardrails.turbot.com/mods/anthropic/mods/anthropic)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/anthropic/enforce_data_residency_for_workspaces
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "anthropic_workspace_data_residency" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceDataResidency"
+  # value    = "Check: Enabled"
+  value    = "Enforce: Set data residency"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/anthropic/enforce_data_residency_for_workspaces/main.tf
+++ b/policy_packs/anthropic/enforce_data_residency_for_workspaces/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Data Residency for Anthropic Workspaces"
+  description = "Keep Anthropic workspace inference within approved geographies by requiring data residency to be configured with an allowed set of inference geos and a default geo."
+  akas        = ["anthropic_enforce_data_residency_for_workspaces"]
+}

--- a/policy_packs/anthropic/enforce_data_residency_for_workspaces/policies.tf
+++ b/policy_packs/anthropic/enforce_data_residency_for_workspaces/policies.tf
@@ -1,0 +1,23 @@
+# Anthropic > Workspace > Data Residency
+resource "turbot_policy_setting" "anthropic_workspace_data_residency" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceDataResidency"
+  value    = "Check: Enabled"
+  # value    = "Enforce: Set data residency"
+}
+
+# Anthropic > Workspace > Data Residency > Allowed Geos
+resource "turbot_policy_setting" "anthropic_workspace_data_residency_allowed_geos" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceDataResidencyAllowedGeos"
+  value    = <<-EOT
+    - "us"
+    EOT
+}
+
+# Anthropic > Workspace > Data Residency > Default Geo
+resource "turbot_policy_setting" "anthropic_workspace_data_residency_default_geo" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceDataResidencyDefaultGeo"
+  value    = "us"
+}

--- a/policy_packs/anthropic/enforce_data_residency_for_workspaces/providers.tf
+++ b/policy_packs/anthropic/enforce_data_residency_for_workspaces/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/README.md
+++ b/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "access management"]
+primary_category: "ai"
+---
+
+# Enforce a Single Billing Owner for Anthropic Workspaces
+
+The `workspace_billing` role on an [Anthropic workspace](https://docs.anthropic.com/en/api/admin-api/workspaces/get-workspace) is the billing-contact role for that workspace. Having two or more `workspace_billing` members on a single workspace is a misconfiguration: billing notifications and invoice routing are intended for a single accountable contact. Keeping exactly one billing owner per workspace makes ownership clear and reduces the chance of missed or duplicated billing communications.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Anthropic workspaces:
+
+- Check or enforce that each workspace has at most one `workspace_billing` member
+- Specify the role that excess billing members are demoted to during enforcement
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/anthropic_enforce_single_billing_owner_for_workspaces/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/anthropic](https://hub.guardrails.turbot.com/mods/anthropic/mods/anthropic)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "anthropic_workspace_excess_billing" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceExcessBilling"
+  # value    = "Check: Enabled"
+  value    = "Enforce: Demote excess to workspace_user"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/main.tf
+++ b/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce a Single Billing Owner for Anthropic Workspaces"
+  description = "Keep billing accountability clear by requiring each Anthropic workspace to have at most one workspace_billing member."
+  akas        = ["anthropic_enforce_single_billing_owner_for_workspaces"]
+}

--- a/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/policies.tf
+++ b/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/policies.tf
@@ -1,0 +1,14 @@
+# Anthropic > Workspace > Excess Billing
+resource "turbot_policy_setting" "anthropic_workspace_excess_billing" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceExcessBilling"
+  value    = "Check: Enabled"
+  # value    = "Enforce: Demote excess to workspace_user"
+}
+
+# Anthropic > Workspace > Excess Billing > Target Role
+resource "turbot_policy_setting" "anthropic_workspace_excess_billing_target_role" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/anthropic#/policy/types/workspaceExcessBillingTargetRole"
+  value    = "workspace_user"
+}

--- a/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/providers.tf
+++ b/policy_packs/anthropic/enforce_single_billing_owner_for_workspaces/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/bedrock/enforce_account_wide_guardrail/README.md
+++ b/policy_packs/aws/bedrock/enforce_account_wide_guardrail/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security"]
+primary_category: "ai"
+---
+
+# Enforce Account-Wide Guardrail for AWS Bedrock
+
+[Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) lets you set an account-level enforced guardrail configuration that applies a guardrail to every in-region model invocation, regardless of whether individual callers attach a guardrail themselves. Enforcing this configuration guarantees that your content and safety policies are applied consistently across all Bedrock usage in an account and region.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Amazon Bedrock:
+
+- Check or enforce that an account-wide enforced guardrail configuration is in place
+- Specify which guardrail identifier and version to enforce (environment-specific, provided as commented examples)
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_bedrock_enforce_account_wide_guardrail/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-bedrock](https://hub.guardrails.turbot.com/mods/aws/mods/aws-bedrock)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/bedrock/enforce_account_wide_guardrail
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_bedrock_enforced_guardrail_configuration_settings" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/enforcedGuardrailConfigurationSettings"
+  # value    = "Check: Configured"
+  value    = "Enforce: Configured"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/bedrock/enforce_account_wide_guardrail/main.tf
+++ b/policy_packs/aws/bedrock/enforce_account_wide_guardrail/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Account-Wide Guardrail for AWS Bedrock"
+  description = "Require an account-level enforced guardrail configuration so a Bedrock guardrail is applied to every in-region model invocation regardless of caller behavior."
+  akas        = ["aws_bedrock_enforce_account_wide_guardrail"]
+}

--- a/policy_packs/aws/bedrock/enforce_account_wide_guardrail/policies.tf
+++ b/policy_packs/aws/bedrock/enforce_account_wide_guardrail/policies.tf
@@ -1,0 +1,27 @@
+# AWS > Bedrock > Enforced Guardrail Configuration > Settings
+resource "turbot_policy_setting" "aws_bedrock_enforced_guardrail_configuration_settings" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/enforcedGuardrailConfigurationSettings"
+  value    = "Check: Configured"
+  # value    = "Enforce: Configured"
+}
+
+# AWS > Bedrock > Enforced Guardrail Configuration > Settings > Guardrail > Identifier
+#
+# The guardrail identifier and version are environment-specific. Uncomment and set
+# these to the guardrail you want enforced before switching the Settings policy to
+# Enforce.
+#
+# resource "turbot_policy_setting" "aws_bedrock_enforced_guardrail_configuration_settings_guardrail_identifier" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/aws-bedrock#/policy/types/enforcedGuardrailConfigurationSettingsGuardrailIdentifier"
+#   value    = "<your-guardrail-id-or-arn>"
+# }
+
+# AWS > Bedrock > Enforced Guardrail Configuration > Settings > Guardrail > Version
+#
+# resource "turbot_policy_setting" "aws_bedrock_enforced_guardrail_configuration_settings_guardrail_version" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/aws-bedrock#/policy/types/enforcedGuardrailConfigurationSettingsGuardrailVersion"
+#   value    = 1
+# }

--- a/policy_packs/aws/bedrock/enforce_account_wide_guardrail/providers.tf
+++ b/policy_packs/aws/bedrock/enforce_account_wide_guardrail/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/README.md
+++ b/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["ai", "access management", "security"]
+primary_category: "ai"
+---
+
+# Enforce AWS Bedrock API Permissions Lockdown
+
+Guardrails manages the IAM permissions granted to Guardrails-managed users and roles for each AWS service. For [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html), the permission policies determine whether those identities can access the Bedrock service and its API. Governing these settings lets you control exactly who can invoke Bedrock through Guardrails-managed access.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Amazon Bedrock:
+
+- Tie Bedrock permissions to whether the service and API are enabled
+- Enable or disable the Bedrock service for Guardrails-managed identities
+- Enable or disable the Bedrock API for Guardrails-managed identities
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_bedrock_enforce_bedrock_api_permissions_lockdown/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-bedrock](https://hub.guardrails.turbot.com/mods/aws/mods/aws-bedrock)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the Bedrock service and API are enabled for Guardrails-managed identities. To lock down access, you can switch these policy settings by adding a comment to the active setting and removing the comment from one of the listed options:
+
+```hcl
+resource "turbot_policy_setting" "aws_bedrock_api_enabled" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockApiEnabled"
+  # value    = "Enabled"
+  value    = "Disabled"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/main.tf
+++ b/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce AWS Bedrock API Permissions Lockdown"
+  description = "Govern which Guardrails-managed identities can access the Amazon Bedrock service and API by enabling Bedrock permissions, service access, and API access."
+  akas        = ["aws_bedrock_enforce_bedrock_api_permissions_lockdown"]
+}

--- a/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/policies.tf
+++ b/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/policies.tf
@@ -1,0 +1,24 @@
+# AWS > Bedrock > Permissions
+resource "turbot_policy_setting" "aws_bedrock_permissions" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockPermissions"
+  value    = "Enabled if AWS > Bedrock > Enabled & AWS > Bedrock > API Enabled"
+  # value    = "Enabled"
+  # value    = "Disabled"
+}
+
+# AWS > Bedrock > Enabled
+resource "turbot_policy_setting" "aws_bedrock_enabled" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockEnabled"
+  value    = "Enabled"
+  # value    = "Disabled"
+}
+
+# AWS > Bedrock > API Enabled
+resource "turbot_policy_setting" "aws_bedrock_api_enabled" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockApiEnabled"
+  value    = "Enabled"
+  # value    = "Disabled"
+}

--- a/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/providers.tf
+++ b/policy_packs/aws/bedrock/enforce_bedrock_api_permissions_lockdown/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/README.md
+++ b/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["ai", "security"]
+primary_category: "ai"
+---
+
+# Enforce Content Filtering for AWS Bedrock Guardrails
+
+[Amazon Bedrock guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) let you apply content filters that screen model prompts and responses for harmful content such as hate speech, insults, sexual content, violence, misconduct, and prompt-injection attacks. Configuring these filters at full strength reduces the risk that your generative AI applications produce or act on unsafe content.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Amazon Bedrock:
+
+- Check or enforce that guardrail content filters are configured
+- Set the hate, insults, sexual, violence, and misconduct filters to `HIGH` strength on both input and output
+- Set the prompt-attack filter to `HIGH` strength on input
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_bedrock_enforce_content_filtering_for_guardrails/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-bedrock](https://hub.guardrails.turbot.com/mods/aws/mods/aws-bedrock)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettings"
+  # value    = "Check: Configured"
+  value    = "Enforce: Configured"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/main.tf
+++ b/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Content Filtering for AWS Bedrock Guardrails"
+  description = "Require harmful-content filters to be configured on Amazon Bedrock guardrails so prompts and responses are screened for hate, insults, sexual, violence, misconduct, and prompt-attack content."
+  akas        = ["aws_bedrock_enforce_content_filtering_for_guardrails"]
+}

--- a/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/policies.tf
+++ b/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/policies.tf
@@ -1,0 +1,84 @@
+# AWS > Bedrock > Guardrail > Settings
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettings"
+  value    = "Check: Configured"
+  # value    = "Enforce: Configured"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Hate Filter Input Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_hate_filter_input_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyHateFilterInputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Hate Filter Output Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_hate_filter_output_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyHateFilterOutputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Insults Filter Input Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_insults_filter_input_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyInsultsFilterInputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Insults Filter Output Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_insults_filter_output_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyInsultsFilterOutputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Sexual Filter Input Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_sexual_filter_input_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicySexualFilterInputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Sexual Filter Output Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_sexual_filter_output_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicySexualFilterOutputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Violence Filter Input Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_violence_filter_input_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyViolenceFilterInputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Violence Filter Output Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_violence_filter_output_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyViolenceFilterOutputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Misconduct Filter Input Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_misconduct_filter_input_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyMisconductFilterInputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Misconduct Filter Output Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_misconduct_filter_output_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyMisconductFilterOutputStrength"
+  value    = "HIGH"
+}
+
+# AWS > Bedrock > Guardrail > Settings > Content Policy > Prompt Attack Filter Input Strength
+resource "turbot_policy_setting" "aws_bedrock_guardrail_settings_content_policy_prompt_attack_filter_input_strength" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/bedrockGuardrailSettingsContentPolicyPromptAttackFilterInputStrength"
+  value    = "HIGH"
+}

--- a/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/providers.tf
+++ b/policy_packs/aws/bedrock/enforce_content_filtering_for_guardrails/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/README.md
+++ b/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security", "data protection"]
+primary_category: "ai"
+---
+
+# Enforce Encryption at Rest for AWS Bedrock Agents
+
+[Encryption at rest](https://turbot.com/guardrails/docs/concepts/guardrails/encryption-at-rest) protects data written to underlying storage. For [Amazon Bedrock agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html), requiring a customer managed KMS key (CMK) instead of an AWS owned key gives you full control over the keys protecting agent data, including key rotation, access policies, and the ability to revoke access.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Amazon Bedrock:
+
+- Check or enforce that Bedrock agents are encrypted at rest with a customer managed key
+- Specify which customer managed KMS key to use (environment-specific, provided as a commented example)
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_bedrock_enforce_encryption_at_rest_for_agents/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-bedrock](https://hub.guardrails.turbot.com/mods/aws/mods/aws-bedrock)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_bedrock_agent_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/agentEncryptionAtRest"
+  # value    = "Check: Customer managed key"
+  value    = "Enforce: Customer managed key"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/main.tf
+++ b/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Encryption at Rest for AWS Bedrock Agents"
+  description = "Require Amazon Bedrock agents to be encrypted at rest with a customer managed KMS key so you retain full control over the keys protecting agent data."
+  akas        = ["aws_bedrock_enforce_encryption_at_rest_for_agents"]
+}

--- a/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/policies.tf
+++ b/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/policies.tf
@@ -1,0 +1,21 @@
+# AWS > Bedrock > Agent > Encryption at Rest
+resource "turbot_policy_setting" "aws_bedrock_agent_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/agentEncryptionAtRest"
+  value    = "Check: Customer managed key"
+  # value    = "Check: AWS owned key"
+  # value    = "Enforce: Customer managed key"
+  # value    = "Enforce: AWS owned key"
+}
+
+# AWS > Bedrock > Agent > Encryption at Rest > Customer Managed Key
+#
+# The KMS key is environment-specific. Uncomment and set this to the customer
+# managed key you want agents encrypted with before switching the Encryption at
+# Rest policy to Enforce: Customer managed key.
+#
+# resource "turbot_policy_setting" "aws_bedrock_agent_encryption_at_rest_customer_managed_key" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/aws-bedrock#/policy/types/agentEncryptionAtRestCustomerManagedKey"
+#   value    = "<your-kms-key-arn>"
+# }

--- a/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/providers.tf
+++ b/policy_packs/aws/bedrock/enforce_encryption_at_rest_for_agents/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/bedrock/enforce_model_invocation_logging/README.md
+++ b/policy_packs/aws/bedrock/enforce_model_invocation_logging/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "logging", "security"]
+primary_category: "ai"
+---
+
+# Enforce Model Invocation Logging for AWS Bedrock
+
+[Amazon Bedrock model invocation logging](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html) captures the prompts, responses, and metadata for every model invocation in your account. Enabling it gives you a complete audit trail of how generative AI models are being used, which is essential for security investigations, compliance evidence, abuse detection, and debugging AI workloads.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Amazon Bedrock:
+
+- Check or enforce that model invocation logging is enabled
+- Specify which data types (text, image, embedding, video) are captured in the logs
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_bedrock_enforce_model_invocation_logging/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-bedrock](https://hub.guardrails.turbot.com/mods/aws/mods/aws-bedrock)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/bedrock/enforce_model_invocation_logging
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_bedrock_settings_model_invocation_logging_configuration" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/settingsModelInvocationLoggingConfiguration"
+  # value    = "Check: Enabled per `Model Invocation Logging Configuration > *`"
+  value    = "Enforce: Enabled per `Model Invocation Logging Configuration > *`"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/bedrock/enforce_model_invocation_logging/main.tf
+++ b/policy_packs/aws/bedrock/enforce_model_invocation_logging/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Model Invocation Logging for AWS Bedrock"
+  description = "Capture a full audit trail of Amazon Bedrock model invocations by requiring model invocation logging to be enabled."
+  akas        = ["aws_bedrock_enforce_model_invocation_logging"]
+}

--- a/policy_packs/aws/bedrock/enforce_model_invocation_logging/policies.tf
+++ b/policy_packs/aws/bedrock/enforce_model_invocation_logging/policies.tf
@@ -1,0 +1,34 @@
+# AWS > Bedrock > Settings > Model Invocation Logging Configuration
+resource "turbot_policy_setting" "aws_bedrock_settings_model_invocation_logging_configuration" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/settingsModelInvocationLoggingConfiguration"
+  value    = "Check: Enabled per `Model Invocation Logging Configuration > *`"
+  # value    = "Check: Disabled"
+  # value    = "Enforce: Enabled per `Model Invocation Logging Configuration > *`"
+  # value    = "Enforce: Disabled"
+}
+
+# AWS > Bedrock > Settings > Model Invocation Logging Configuration > Data Delivery
+resource "turbot_policy_setting" "aws_bedrock_settings_model_invocation_logging_configuration_data_delivery" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-bedrock#/policy/types/settingsModelInvocationLoggingConfigurationDataDelivery"
+  value    = <<-EOT
+    - "Text"
+    - "Image"
+    - "Embedding"
+    - "Video"
+    EOT
+}
+
+# AWS > Bedrock > Settings > Model Invocation Logging Configuration > Logging Destination
+#
+# The logging destination requires environment-specific values (S3 bucket, CloudWatch log
+# group, and a service role ARN). Uncomment and set these to enable enforcement.
+#
+# resource "turbot_policy_setting" "aws_bedrock_settings_model_invocation_logging_configuration_logging_destination" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/aws-bedrock#/policy/types/settingsModelInvocationLoggingConfigurationLoggingDestination"
+#   value    = "Both S3 and Cloudwatch Logs"
+#   # value    = "S3 only"
+#   # value    = "Cloudwatch Logs only"
+# }

--- a/policy_packs/aws/bedrock/enforce_model_invocation_logging/providers.tf
+++ b/policy_packs/aws/bedrock/enforce_model_invocation_logging/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/README.md
+++ b/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security", "access management"]
+primary_category: "ai"
+---
+
+# Enforce Allowed Authentication Types for Azure AI Foundry Connections
+
+Azure AI Foundry connections store credentials that link a project to external resources such as storage, search, and other AI services. Restricting connections to an approved set of authentication types lets you prefer identity-based methods (managed identity, Microsoft Entra ID) over long-lived shared secrets, reducing the risk of leaked credentials.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry connections:
+
+- Check or enforce that connections use only allowed authentication types
+- Specify the list of allowed authentication types
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_allowed_auth_types_for_connections/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_connection_allowed_auth_type" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/connectionAllowedAuthType"
+  # value    = "Check: Allowed auth type"
+  value    = "Enforce: Delete if auth type not allowed"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Allowed Authentication Types for Azure AI Foundry Connections"
+  description = "Restrict Azure AI Foundry connections to an approved set of authentication types so that only sanctioned credential methods are used."
+  akas        = ["azure_aifoundry_enforce_allowed_auth_types_for_connections"]
+}

--- a/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/policies.tf
@@ -1,0 +1,19 @@
+# Azure > AI Foundry > Connection > Allowed > Auth Type
+resource "turbot_policy_setting" "azure_aifoundry_connection_allowed_auth_type" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/connectionAllowedAuthType"
+  value    = "Check: Allowed auth type"
+  # value    = "Enforce: Delete if auth type not allowed"
+  # value    = "Enforce: Delete if auth type not allowed and resource is new"
+}
+
+# Azure > AI Foundry > Connection > Allowed > Auth Type > Types
+resource "turbot_policy_setting" "azure_aifoundry_connection_allowed_auth_type_types" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/connectionAllowedAuthTypeTypes"
+  value    = <<-EOT
+    - "ApiKey"
+    - "ManagedIdentity"
+    - "AAD"
+    EOT
+}

--- a/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_allowed_auth_types_for_connections/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/README.md
+++ b/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security"]
+primary_category: "ai"
+---
+
+# Enforce Allowed Model Names for Azure AI Foundry Deployments
+
+Azure AI Foundry deployments can host a wide range of models. Restricting deployments to an approved set of model names ensures that only vetted, sanctioned models are used in your environment, which helps with cost control, compliance, and avoiding unreviewed or deprecated models.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry deployments:
+
+- Check or enforce that deployments use only allowed model names
+- Specify the list of allowed model names
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_allowed_model_names_for_deployments/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_deployment_allowed_model_name" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentAllowedModelName"
+  # value    = "Check: Allowed model name"
+  value    = "Enforce: Delete if model name not allowed"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Allowed Model Names for Azure AI Foundry Deployments"
+  description = "Restrict Azure AI Foundry deployments to an approved set of model names so that only sanctioned models are deployed."
+  akas        = ["azure_aifoundry_enforce_allowed_model_names_for_deployments"]
+}

--- a/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/policies.tf
@@ -1,0 +1,18 @@
+# Azure > AI Foundry > Deployment > Allowed > Model Name
+resource "turbot_policy_setting" "azure_aifoundry_deployment_allowed_model_name" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentAllowedModelName"
+  value    = "Check: Allowed model name"
+  # value    = "Enforce: Delete if model name not allowed"
+  # value    = "Enforce: Delete if model name not allowed and resource is new"
+}
+
+# Azure > AI Foundry > Deployment > Allowed > Model Name > Names
+resource "turbot_policy_setting" "azure_aifoundry_deployment_allowed_model_name_names" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentAllowedModelNameNames"
+  value    = <<-EOT
+    - "gpt-4o"
+    - "gpt-4o-mini"
+    EOT
+}

--- a/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_allowed_model_names_for_deployments/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/README.md
+++ b/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security", "data protection"]
+primary_category: "ai"
+---
+
+# Enforce Encryption at Rest for Azure AI Foundry Accounts
+
+Azure AI Foundry accounts (Cognitive Services accounts with `kind=AIServices`) encrypt data at rest by default with a Microsoft managed key. For sensitive AI workloads, you may need to control the encryption key yourself using a customer managed key (CMK) sourced from Azure Key Vault. This gives you control over key rotation, revocation, and access, which is often required for compliance.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry accounts:
+
+- Check or enforce the encryption at rest posture (Microsoft managed key or customer managed key)
+- Optionally pin enforcement to a specific Azure Key Vault key
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_encryption_at_rest_for_accounts/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_account_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountEncryptionAtRest"
+  # value    = "Check: Customer managed key"
+  value    = "Enforce: Customer managed key"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Encryption at Rest for Azure AI Foundry Accounts"
+  description = "Protect data written to Azure AI Foundry accounts by requiring a specific encryption at rest posture, such as a customer managed key."
+  akas        = ["azure_aifoundry_enforce_encryption_at_rest_for_accounts"]
+}

--- a/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/policies.tf
@@ -1,0 +1,21 @@
+# Azure > AI Foundry > Account > Encryption at Rest
+resource "turbot_policy_setting" "azure_aifoundry_account_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountEncryptionAtRest"
+  value    = "Check: Customer managed key"
+  # value    = "Check: Microsoft managed key"
+  # value    = "Enforce: Customer managed key"
+  # value    = "Enforce: Microsoft managed key"
+}
+
+# Azure > AI Foundry > Account > Encryption at Rest > Customer Managed Key
+#
+# The customer managed key requires an environment-specific Key Vault key URL. The key must
+# already exist in CMDB as an `Azure > Key Vault > Key` resource. Uncomment and set this to
+# enable enforcement against a specific key.
+#
+# resource "turbot_policy_setting" "azure_aifoundry_account_encryption_at_rest_customer_managed_key" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountEncryptionAtRestCustomerManagedKey"
+#   value    = "https://my-key-vault.vault.azure.net/keys/my-key"
+# }

--- a/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_encryption_at_rest_for_accounts/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/README.md
+++ b/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/README.md
@@ -1,0 +1,101 @@
+---
+categories: ["ai", "security", "access management"]
+primary_category: "ai"
+---
+
+# Enforce Local Authentication Is Disabled for Azure AI Foundry Accounts
+
+Azure AI Foundry accounts (Cognitive Services accounts with `kind=AIServices`) permit local authentication with API keys by default. API keys are long-lived shared secrets that are easy to leak and hard to rotate. Disabling local authentication forces all access through Microsoft Entra ID (AAD), which gives you centralized identity, conditional access, and full audit logging for an identity-only governance posture.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry accounts:
+
+- Check or enforce that local (API key) authentication is disabled
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_local_auth_disabled_for_accounts/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_account_local_auth" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountLocalAuth"
+  # value    = "Check: Disabled"
+  value    = "Enforce: Disabled"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Local Authentication Is Disabled for Azure AI Foundry Accounts"
+  description = "Require Azure AI Foundry accounts to disable local (API key) authentication so that only Microsoft Entra ID identities can access the account."
+  akas        = ["azure_aifoundry_enforce_local_auth_disabled_for_accounts"]
+}

--- a/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/policies.tf
@@ -1,0 +1,9 @@
+# Azure > AI Foundry > Account > Local Auth
+resource "turbot_policy_setting" "azure_aifoundry_account_local_auth" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountLocalAuth"
+  value    = "Check: Disabled"
+  # value    = "Check: Enabled"
+  # value    = "Enforce: Disabled"
+  # value    = "Enforce: Enabled"
+}

--- a/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_local_auth_disabled_for_accounts/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/README.md
+++ b/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security"]
+primary_category: "ai"
+---
+
+# Enforce Approved Model Version for Azure AI Foundry Deployments
+
+Azure AI Foundry deployments reference a specific model version, and Azure can auto-upgrade versions over time. Pinning deployments to an approved model version ensures workloads run on a known, tested version, which avoids unexpected behavior changes and keeps results reproducible.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry deployments:
+
+- Check or enforce that deployments use an approved model version
+- Specify the required model version
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_model_version_for_deployments/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_model_version_for_deployments
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_deployment_model_version" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentModelVersion"
+  # value    = "Check: per `Model Version > Required Version`"
+  value    = "Enforce: per `Model Version > Required Version`"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Approved Model Version for Azure AI Foundry Deployments"
+  description = "Pin Azure AI Foundry deployments to an approved model version so that workloads run on a known, tested version of the model."
+  akas        = ["azure_aifoundry_enforce_model_version_for_deployments"]
+}

--- a/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/policies.tf
@@ -1,0 +1,14 @@
+# Azure > AI Foundry > Deployment > Model Version
+resource "turbot_policy_setting" "azure_aifoundry_deployment_model_version" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentModelVersion"
+  value    = "Check: per `Model Version > Required Version`"
+  # value    = "Enforce: per `Model Version > Required Version`"
+}
+
+# Azure > AI Foundry > Deployment > Model Version > Required Version
+resource "turbot_policy_setting" "azure_aifoundry_deployment_model_version_required_version" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentModelVersionRequiredVersion"
+  value    = "2024-08-06"
+}

--- a/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_model_version_for_deployments/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/README.md
+++ b/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security", "networking"]
+primary_category: "ai"
+---
+
+# Enforce Restricted Outbound Network Access for Azure AI Foundry Accounts
+
+Azure AI Foundry accounts (Cognitive Services accounts with `kind=AIServices`) allow unrestricted outbound network access by default. Restricting outbound access to an explicit allow-list of fully-qualified domain names (FQDNs) limits where the account can connect, which helps prevent data exfiltration and contains the blast radius if the account is compromised.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry accounts:
+
+- Check or enforce that outbound network access is restricted to an allow-list of FQDNs
+- Specify the list of FQDNs the account is allowed to reach
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_outbound_network_access_for_accounts/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_account_outbound_network_access" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountOutboundNetworkAccess"
+  # value    = "Check: Allow outbound per `Outbound Network Access > Allowed FQDNs`"
+  value    = "Enforce: Allow outbound per `Outbound Network Access > Allowed FQDNs`"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Restricted Outbound Network Access for Azure AI Foundry Accounts"
+  description = "Limit where Azure AI Foundry accounts can connect by restricting outbound network access to an explicit list of allowed FQDNs."
+  akas        = ["azure_aifoundry_enforce_outbound_network_access_for_accounts"]
+}

--- a/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/policies.tf
@@ -1,0 +1,20 @@
+# Azure > AI Foundry > Account > Outbound Network Access
+resource "turbot_policy_setting" "azure_aifoundry_account_outbound_network_access" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountOutboundNetworkAccess"
+  value    = "Check: Allow outbound per `Outbound Network Access > Allowed FQDNs`"
+  # value    = "Check: Allow all outbound network access"
+  # value    = "Enforce: Allow outbound per `Outbound Network Access > Allowed FQDNs`"
+  # value    = "Enforce: Allow all outbound network access"
+}
+
+# Azure > AI Foundry > Account > Outbound Network Access > Allowed FQDNs
+resource "turbot_policy_setting" "azure_aifoundry_account_outbound_network_access_allowed_fqdns" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountOutboundNetworkAccessAllowedFqdns"
+  value    = []
+  # Add the FQDNs the account is allowed to reach, for example:
+  # value    = <<-EOT
+  #   - "*.openai.azure.com"
+  #   EOT
+}

--- a/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_outbound_network_access_for_accounts/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/README.md
+++ b/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/README.md
@@ -1,0 +1,101 @@
+---
+categories: ["ai", "security", "networking"]
+primary_category: "ai"
+---
+
+# Enforce Public Network Access Is Disabled for Azure AI Foundry Accounts
+
+Azure AI Foundry accounts (Cognitive Services accounts with `kind=AIServices`) can accept connections over the public internet by default. Disabling public network access ensures the account is only reachable through private endpoints, which is the recommended posture for production AI workloads and significantly reduces the network attack surface.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry accounts:
+
+- Check or enforce that public network access is disabled
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_public_network_access_disabled_for_accounts/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_account_public_network_access" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountPublicNetworkAccess"
+  # value    = "Check: Disabled"
+  value    = "Enforce: Disabled"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Public Network Access Is Disabled for Azure AI Foundry Accounts"
+  description = "Reduce the network attack surface of Azure AI Foundry accounts by requiring public network access to be disabled so the account is only reachable through private endpoints."
+  akas        = ["azure_aifoundry_enforce_public_network_access_disabled_for_accounts"]
+}

--- a/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/policies.tf
@@ -1,0 +1,9 @@
+# Azure > AI Foundry > Account > Public Network Access
+resource "turbot_policy_setting" "azure_aifoundry_account_public_network_access" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/accountPublicNetworkAccess"
+  value    = "Check: Disabled"
+  # value    = "Check: Enabled"
+  # value    = "Enforce: Disabled"
+  # value    = "Enforce: Enabled"
+}

--- a/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_public_network_access_disabled_for_accounts/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/README.md
+++ b/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["ai", "security"]
+primary_category: "ai"
+---
+
+# Enforce Responsible AI Policy for Azure AI Foundry Deployments
+
+Azure AI Foundry deployments apply a Responsible AI (RAI) policy that defines the content filters protecting the model from generating or accepting harmful content. Requiring deployments to use a specific approved RAI policy ensures consistent content safety guardrails across all of your generative AI workloads.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure AI Foundry deployments:
+
+- Check or enforce that deployments use an approved RAI policy
+- Specify the required RAI policy name
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_aifoundry_enforce_rai_policy_for_deployments/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-aifoundry](https://hub.guardrails.turbot.com/mods/azure/mods/azure-aifoundry)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_aifoundry_deployment_rai_policy" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentRaiPolicy"
+  # value    = "Check: per `RAI Policy > Name`"
+  value    = "Enforce: per `RAI Policy > Name`"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/main.tf
+++ b/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Responsible AI Policy for Azure AI Foundry Deployments"
+  description = "Require Azure AI Foundry deployments to use an approved Responsible AI (RAI) content filtering policy."
+  akas        = ["azure_aifoundry_enforce_rai_policy_for_deployments"]
+}

--- a/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/policies.tf
+++ b/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/policies.tf
@@ -1,0 +1,14 @@
+# Azure > AI Foundry > Deployment > RAI Policy
+resource "turbot_policy_setting" "azure_aifoundry_deployment_rai_policy" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentRaiPolicy"
+  value    = "Check: per `RAI Policy > Name`"
+  # value    = "Enforce: per `RAI Policy > Name`"
+}
+
+# Azure > AI Foundry > Deployment > RAI Policy > Name
+resource "turbot_policy_setting" "azure_aifoundry_deployment_rai_policy_name" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-aifoundry#/policy/types/deploymentRaiPolicyName"
+  value    = "Microsoft.DefaultV2"
+}

--- a/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/providers.tf
+++ b/policy_packs/azure/aifoundry/enforce_rai_policy_for_deployments/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/README.md
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["ai", "security", "data protection"]
+primary_category: "ai"
+---
+
+# Enforce Encryption at Rest for GCP Vertex AI Deployment Resource Pools
+
+[GCP Vertex AI deployment resource pools](https://cloud.google.com/vertex-ai/docs/predictions/use-deployment-resource-pools) let you share dedicated compute resources across multiple deployed models. Encrypting the data on these pools at rest, especially with a customer managed encryption key (CMEK), gives you control over the key lifecycle and helps satisfy security, compliance, and data residency requirements.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GCP Vertex AI deployment resource pools:
+
+- Check or enforce that deployment resource pools use an allowed encryption at rest level
+- Specify the required encryption level (Google managed key or customer managed key)
+- Optionally pin encryption to a specific customer managed key (CMEK)
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_vertexai_enforce_encryption_at_rest_for_deployment_resource_pools/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/gcp-vertexai](https://hub.guardrails.turbot.com/mods/gcp/mods/gcp-vertexai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "gcp_vertexai_deployment_resource_pool_allowed_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/deploymentResourcePoolAllowedEncryptionAtRest"
+  # value    = "Check: Allowed encryption level"
+  value    = "Enforce: Delete if encryption level not allowed and resource is new"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/main.tf
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Encryption at Rest for GCP Vertex AI Deployment Resource Pools"
+  description = "Protect data on GCP Vertex AI deployment resource pools by requiring an approved encryption at rest configuration."
+  akas        = ["gcp_vertexai_enforce_encryption_at_rest_for_deployment_resource_pools"]
+}

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/policies.tf
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/policies.tf
@@ -1,0 +1,27 @@
+# GCP > Vertex AI > Deployment Resource Pool > Allowed > Encryption at Rest
+resource "turbot_policy_setting" "gcp_vertexai_deployment_resource_pool_allowed_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/deploymentResourcePoolAllowedEncryptionAtRest"
+  value    = "Check: Allowed encryption level"
+  # value    = "Enforce: Delete if encryption level not allowed and resource is new"
+}
+
+# GCP > Vertex AI > Deployment Resource Pool > Allowed > Encryption at Rest > Level
+resource "turbot_policy_setting" "gcp_vertexai_deployment_resource_pool_allowed_encryption_at_rest_level" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/deploymentResourcePoolAllowedEncryptionAtRestLevel"
+  value    = "Customer managed key"
+  # value    = "Google managed key"
+  # value    = "Google managed key or higher"
+}
+
+# GCP > Vertex AI > Deployment Resource Pool > Allowed > Encryption at Rest > Level > Customer Managed Key
+#
+# The customer managed key requires an environment-specific GCP KMS key path. Uncomment and
+# set this to the KMS key you want to enforce for deployment resource pool encryption at rest.
+#
+# resource "turbot_policy_setting" "gcp_vertexai_deployment_resource_pool_allowed_encryption_at_rest_customer_managed_key" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/gcp-vertexai#/policy/types/deploymentResourcePoolAllowedEncryptionAtRestCustomerManagedKey"
+#   value    = "<your-kms-key-path>"
+# }

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/providers.tf
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_deployment_resource_pools/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/README.md
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["ai", "security", "data protection"]
+primary_category: "ai"
+---
+
+# Enforce Encryption at Rest for GCP Vertex AI Endpoints
+
+[GCP Vertex AI endpoints](https://cloud.google.com/vertex-ai/docs/general/deployment) serve your deployed models for online prediction, and they store model artifacts and associated data. Encrypting that data at rest, especially with a customer managed encryption key (CMEK), gives you control over the key lifecycle and helps satisfy security, compliance, and data residency requirements.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GCP Vertex AI endpoints:
+
+- Check or enforce that endpoints use an allowed encryption at rest level
+- Specify the required encryption level (Google managed key or customer managed key)
+- Optionally pin encryption to a specific customer managed key (CMEK)
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_vertexai_enforce_encryption_at_rest_for_endpoints/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/gcp-vertexai](https://hub.guardrails.turbot.com/mods/gcp/mods/gcp-vertexai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "gcp_vertexai_endpoint_allowed_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/endpointAllowedEncryptionAtRest"
+  # value    = "Check: Allowed encryption level"
+  value    = "Enforce: Delete if encryption level not allowed and resource is new"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/main.tf
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Encryption at Rest for GCP Vertex AI Endpoints"
+  description = "Protect data on GCP Vertex AI endpoints by requiring an approved encryption at rest configuration."
+  akas        = ["gcp_vertexai_enforce_encryption_at_rest_for_endpoints"]
+}

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/policies.tf
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/policies.tf
@@ -1,0 +1,27 @@
+# GCP > Vertex AI > Endpoint > Allowed > Encryption at Rest
+resource "turbot_policy_setting" "gcp_vertexai_endpoint_allowed_encryption_at_rest" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/endpointAllowedEncryptionAtRest"
+  value    = "Check: Allowed encryption level"
+  # value    = "Enforce: Delete if encryption level not allowed and resource is new"
+}
+
+# GCP > Vertex AI > Endpoint > Allowed > Encryption at Rest > Level
+resource "turbot_policy_setting" "gcp_vertexai_endpoint_allowed_encryption_at_rest_level" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/endpointAllowedEncryptionAtRestLevel"
+  value    = "Customer managed key"
+  # value    = "Google managed key"
+  # value    = "Google managed key or higher"
+}
+
+# GCP > Vertex AI > Endpoint > Allowed > Encryption at Rest > Level > Customer Managed Key
+#
+# The customer managed key requires an environment-specific GCP KMS key path. Uncomment and
+# set this to the KMS key you want to enforce for endpoint encryption at rest.
+#
+# resource "turbot_policy_setting" "gcp_vertexai_endpoint_allowed_encryption_at_rest_customer_managed_key" {
+#   resource = turbot_policy_pack.main.id
+#   type     = "tmod:@turbot/gcp-vertexai#/policy/types/endpointAllowedEncryptionAtRestCustomerManagedKey"
+#   value    = "<your-kms-key-path>"
+# }

--- a/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/providers.tf
+++ b/policy_packs/gcp/vertexai/enforce_encryption_at_rest_for_endpoints/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/README.md
+++ b/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/README.md
@@ -1,0 +1,100 @@
+---
+categories: ["ai", "logging", "security"]
+primary_category: "ai"
+---
+
+# Enforce Request-Response Logging for GCP Vertex AI Endpoints
+
+[GCP Vertex AI request-response logging](https://cloud.google.com/vertex-ai/docs/predictions/online-prediction-logging) captures a sample of the prediction requests and responses served by an endpoint to a BigQuery table. Enabling it gives you an audit trail of how deployed models are being used, which is valuable for monitoring model behavior, troubleshooting, abuse detection, and compliance evidence.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GCP Vertex AI endpoints:
+
+- Check that request-response logging is enabled
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_vertexai_enforce_request_response_logging_for_endpoints/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/gcp-vertexai](https://hub.guardrails.turbot.com/mods/gcp/mods/gcp-vertexai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+This control checks that request-response logging is enabled and raises an alarm when it is not. To disable the check entirely, you can set the policy to `Skip`:
+
+```hcl
+resource "turbot_policy_setting" "gcp_vertexai_endpoint_active_request_response_logging" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/endpointActiveRequestResponseLogging"
+  value    = "Skip"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/main.tf
+++ b/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Request-Response Logging for GCP Vertex AI Endpoints"
+  description = "Capture an audit trail of GCP Vertex AI endpoint predictions by requiring request-response logging to be enabled."
+  akas        = ["gcp_vertexai_enforce_request_response_logging_for_endpoints"]
+}

--- a/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/policies.tf
+++ b/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/policies.tf
@@ -1,0 +1,6 @@
+# GCP > Vertex AI > Endpoint > Active > Request-Response Logging
+resource "turbot_policy_setting" "gcp_vertexai_endpoint_active_request_response_logging" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-vertexai#/policy/types/endpointActiveRequestResponseLogging"
+  value    = "Check: Enabled"
+}

--- a/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/providers.tf
+++ b/policy_packs/gcp/vertexai/enforce_request_response_logging_for_endpoints/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/openai/enforce_admin_api_key_rotation/README.md
+++ b/policy_packs/openai/enforce_admin_api_key_rotation/README.md
@@ -1,0 +1,104 @@
+---
+categories: ["ai", "access management", "security"]
+primary_category: "ai"
+---
+
+# Enforce Admin API Key Rotation for OpenAI
+
+OpenAI [Admin API keys](https://platform.openai.com/docs/api-reference/admin-api-keys) carry organization-wide privileges, so a stale or leaked admin key is far more damaging than a project key. Rotating admin keys on a regular cadence, and removing those that have gone idle, limits the blast radius of a compromised credential and keeps organization administration tied to active operators.
+
+Admin API keys do not carry a status enum, so the `Active` control evaluates the key's age and how recently it was used. Keys that have not been used inside the configured window are treated as inactive, raising an alarm and, with enforcement enabled, being deleted after a warning period. The calling admin key that Guardrails uses to manage the organization is skipped by the control.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for OpenAI:
+
+- Check or enforce that OpenAI Admin API keys are actively used and rotated
+- Specify the recently-used window after which an Admin API key is treated as inactive
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/openai_enforce_admin_api_key_rotation/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/openai](https://hub.guardrails.turbot.com/mods/openai/mods/openai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/openai/enforce_admin_api_key_rotation
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "openai_admin_api_key_active" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/adminApiKeyActive"
+  # value    = "Check: Active"
+  value    = "Enforce: Delete inactive with 90 days warning"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/openai/enforce_admin_api_key_rotation/main.tf
+++ b/policy_packs/openai/enforce_admin_api_key_rotation/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Admin API Key Rotation for OpenAI"
+  description = "Promote OpenAI Admin API key rotation by treating admin keys that have not been used recently as inactive and optionally deleting them."
+  akas        = ["openai_enforce_admin_api_key_rotation"]
+}

--- a/policy_packs/openai/enforce_admin_api_key_rotation/policies.tf
+++ b/policy_packs/openai/enforce_admin_api_key_rotation/policies.tf
@@ -1,0 +1,14 @@
+# OpenAI > Admin API Key > Active
+resource "turbot_policy_setting" "openai_admin_api_key_active" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/adminApiKeyActive"
+  value    = "Check: Active"
+  # value    = "Enforce: Delete inactive with 90 days warning"
+}
+
+# OpenAI > Admin API Key > Active > Recently Used
+resource "turbot_policy_setting" "openai_admin_api_key_active_recently_used" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/adminApiKeyActiveRecentlyUsed"
+  value    = "Active if recently used <= 90 days"
+}

--- a/policy_packs/openai/enforce_admin_api_key_rotation/providers.tf
+++ b/policy_packs/openai/enforce_admin_api_key_rotation/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/openai/enforce_allowed_email_domains_for_users/README.md
+++ b/policy_packs/openai/enforce_allowed_email_domains_for_users/README.md
@@ -1,0 +1,104 @@
+---
+categories: ["ai", "access management"]
+primary_category: "ai"
+---
+
+# Enforce Allowed Email Domains for OpenAI Users
+
+Membership in your OpenAI organization should be limited to people on your corporate identity. Restricting [organization users](https://platform.openai.com/docs/api-reference/users) to an allowlist of email-address domains keeps personal or partner accounts out of the organization, supports offboarding, and gives you a clear, auditable boundary for who can access your AI workloads.
+
+The `Allowed > Email Domain` control evaluates the domain of each user's email address against an allowlist using `micromatch`, so wildcard patterns such as `*.acme.com` are supported. Owner-role users are alarm-only and are never deleted. With enforcement enabled, the control deletes disallowed non-owner users.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for OpenAI:
+
+- Check or enforce that OpenAI organization users belong to an allowed email domain
+- Specify the list of allowed email-address domain patterns
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/openai_enforce_allowed_email_domains_for_users/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/openai](https://hub.guardrails.turbot.com/mods/openai/mods/openai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/openai/enforce_allowed_email_domains_for_users
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "openai_user_allowed_email_domain" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/userAllowedEmailDomain"
+  # value    = "Check: Allowed"
+  value    = "Enforce: Delete if domain not allowed"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/openai/enforce_allowed_email_domains_for_users/main.tf
+++ b/policy_packs/openai/enforce_allowed_email_domains_for_users/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Allowed Email Domains for OpenAI Users"
+  description = "Restrict OpenAI organization users to an allowlist of email-address domains, optionally deleting users whose domain is not allowed."
+  akas        = ["openai_enforce_allowed_email_domains_for_users"]
+}

--- a/policy_packs/openai/enforce_allowed_email_domains_for_users/policies.tf
+++ b/policy_packs/openai/enforce_allowed_email_domains_for_users/policies.tf
@@ -1,0 +1,17 @@
+# OpenAI > User > Allowed > Email Domain
+resource "turbot_policy_setting" "openai_user_allowed_email_domain" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/userAllowedEmailDomain"
+  value    = "Check: Allowed"
+  # value    = "Enforce: Delete if domain not allowed"
+}
+
+# OpenAI > User > Allowed > Email Domain > Domains
+resource "turbot_policy_setting" "openai_user_allowed_email_domain_domains" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/userAllowedEmailDomainDomains"
+  value    = <<-EOT
+    - "acme.com"
+    - "*.acme.com"
+    EOT
+}

--- a/policy_packs/openai/enforce_allowed_email_domains_for_users/providers.tf
+++ b/policy_packs/openai/enforce_allowed_email_domains_for_users/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/openai/enforce_api_key_rotation/README.md
+++ b/policy_packs/openai/enforce_api_key_rotation/README.md
@@ -1,0 +1,104 @@
+---
+categories: ["ai", "access management", "security"]
+primary_category: "ai"
+---
+
+# Enforce API Key Rotation for OpenAI
+
+Long-lived OpenAI [API keys](https://platform.openai.com/docs/api-reference/authentication) that linger after a project, integration, or person has moved on are a standing credential-theft risk. Rotating keys on a regular cadence, and removing those that have gone idle, shrinks the window an exposed key can be abused and keeps your project credentials tied to active workloads.
+
+OpenAI project API keys do not carry a status field, so the `Active` control evaluates the key's age and how recently it was used. Keys that have not been used inside the configured window are treated as inactive, raising an alarm and, with enforcement enabled, being deleted after a warning period.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for OpenAI:
+
+- Check or enforce that OpenAI API keys are actively used and rotated
+- Specify the recently-used window after which an API key is treated as inactive
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/openai_enforce_api_key_rotation/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/openai](https://hub.guardrails.turbot.com/mods/openai/mods/openai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/openai/enforce_api_key_rotation
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "openai_api_key_active" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/apiKeyActive"
+  # value    = "Check: Active"
+  value    = "Enforce: Delete inactive with 90 days warning"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/openai/enforce_api_key_rotation/main.tf
+++ b/policy_packs/openai/enforce_api_key_rotation/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce API Key Rotation for OpenAI"
+  description = "Promote OpenAI API key rotation by treating keys that have not been used recently as inactive and optionally deleting them."
+  akas        = ["openai_enforce_api_key_rotation"]
+}

--- a/policy_packs/openai/enforce_api_key_rotation/policies.tf
+++ b/policy_packs/openai/enforce_api_key_rotation/policies.tf
@@ -1,0 +1,14 @@
+# OpenAI > Project > API Key > Active
+resource "turbot_policy_setting" "openai_api_key_active" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/apiKeyActive"
+  value    = "Check: Active"
+  # value    = "Enforce: Delete inactive with 90 days warning"
+}
+
+# OpenAI > Project > API Key > Active > Recently Used
+resource "turbot_policy_setting" "openai_api_key_active_recently_used" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/apiKeyActiveRecentlyUsed"
+  value    = "Active if recently used <= 90 days"
+}

--- a/policy_packs/openai/enforce_api_key_rotation/providers.tf
+++ b/policy_packs/openai/enforce_api_key_rotation/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/openai/enforce_approved_models_for_projects/README.md
+++ b/policy_packs/openai/enforce_approved_models_for_projects/README.md
@@ -1,0 +1,104 @@
+---
+categories: ["ai", "security"]
+primary_category: "ai"
+---
+
+# Enforce Approved Models for OpenAI Projects
+
+OpenAI [projects](https://platform.openai.com/docs/guides/production-best-practices) carry per-model rate-limit entries that determine which models a project can call. Restricting projects to an approved set of models keeps teams on the models you have vetted for cost, capability, and data-handling, and prevents shadow usage of models that have not been reviewed.
+
+The `Approved Models` control walks each project's rate-limit entries and raises an alarm for any entry whose model is not on the approved list. With enforcement enabled, the control zeroes the rate limits on disallowed entries, effectively disabling those models for the project.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for OpenAI:
+
+- Check or enforce that OpenAI projects only use approved models
+- Specify the list of OpenAI model ids permitted for use on projects
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/openai_enforce_approved_models_for_projects/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/openai](https://hub.guardrails.turbot.com/mods/openai/mods/openai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/openai/enforce_approved_models_for_projects
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "openai_project_rate_limit_approved_models" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/projectRateLimitApprovedModels"
+  # value    = "Check: Approved"
+  value    = "Enforce: Set zero-RPM on disallowed models"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/openai/enforce_approved_models_for_projects/main.tf
+++ b/policy_packs/openai/enforce_approved_models_for_projects/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Approved Models for OpenAI Projects"
+  description = "Restrict OpenAI projects to an approved list of models by checking project rate-limit entries against an allowlist."
+  akas        = ["openai_enforce_approved_models_for_projects"]
+}

--- a/policy_packs/openai/enforce_approved_models_for_projects/policies.tf
+++ b/policy_packs/openai/enforce_approved_models_for_projects/policies.tf
@@ -1,0 +1,19 @@
+# OpenAI > Project > Approved Models
+resource "turbot_policy_setting" "openai_project_rate_limit_approved_models" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/projectRateLimitApprovedModels"
+  value    = "Check: Approved"
+  # value    = "Enforce: Set zero-RPM on disallowed models"
+  # value    = "Enforce: Set zero-RPM on disallowed models if new"
+}
+
+# OpenAI > Project > Approved Models > Approved Models List
+resource "turbot_policy_setting" "openai_project_rate_limit_approved_models_list" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/projectRateLimitApprovedModelsList"
+  value    = <<-EOT
+    - "gpt-4o"
+    - "gpt-4o-mini"
+    - "text-embedding-3-large"
+    EOT
+}

--- a/policy_packs/openai/enforce_approved_models_for_projects/providers.tf
+++ b/policy_packs/openai/enforce_approved_models_for_projects/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/openai/enforce_zero_data_retention/README.md
+++ b/policy_packs/openai/enforce_zero_data_retention/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["ai", "data protection", "compliance"]
+primary_category: "ai"
+---
+
+# Enforce Zero Data Retention for OpenAI
+
+[Zero Data Retention (ZDR)](https://platform.openai.com/docs/guides/your-data) and Modified Abuse Monitoring are contractual, Console-only controls that stop OpenAI from retaining your API inputs and outputs. Confirming they are enabled is essential evidence for data protection reviews, privacy commitments, and compliance frameworks that restrict how long prompt and completion data may be stored.
+
+OpenAI exposes no Admin API endpoint to probe ZDR state, so the control reads an operator attestation. Once you have configured ZDR and Modified Abuse Monitoring with OpenAI, an operator sets the attestation to confirm the organization is compliant.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for OpenAI:
+
+- Check that Zero Data Retention and Modified Abuse Monitoring are enabled for the organization
+- Capture the operator attestation that confirms the organization is compliant
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/openai_enforce_zero_data_retention/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/openai](https://hub.guardrails.turbot.com/mods/openai/mods/openai)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/openai/enforce_zero_data_retention
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+This control verifies an operator attestation and has no automated enforcement variant. After you have configured Zero Data Retention and Modified Abuse Monitoring with OpenAI, set the attestation to `true` so the control reports compliance:
+
+```hcl
+resource "turbot_policy_setting" "openai_organization_zdr_status_attested" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/zdrStatusAttested"
+  value    = true
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/openai/enforce_zero_data_retention/main.tf
+++ b/policy_packs/openai/enforce_zero_data_retention/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Zero Data Retention for OpenAI"
+  description = "Verify that the OpenAI organization has Zero Data Retention (ZDR) and Modified Abuse Monitoring enabled, based on an operator attestation."
+  akas        = ["openai_enforce_zero_data_retention"]
+}

--- a/policy_packs/openai/enforce_zero_data_retention/policies.tf
+++ b/policy_packs/openai/enforce_zero_data_retention/policies.tf
@@ -1,0 +1,17 @@
+# OpenAI > Organization > ZDR Status
+resource "turbot_policy_setting" "openai_organization_zdr_status" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/zdrStatus"
+  value    = "Check: Enabled"
+}
+
+# OpenAI > Organization > ZDR Status > ZDR Status Attested
+#
+# No Admin API endpoint exposes ZDR state, so this control cannot auto-verify. After
+# you have configured Zero Data Retention and Modified Abuse Monitoring with OpenAI,
+# an operator should set this value to `true` to attest that the organization is compliant.
+resource "turbot_policy_setting" "openai_organization_zdr_status_attested" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/openai#/policy/types/zdrStatusAttested"
+  value    = false
+}

--- a/policy_packs/openai/enforce_zero_data_retention/providers.tf
+++ b/policy_packs/openai/enforce_zero_data_retention/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
## What

Adds 25 policy packs showcasing AI governance controls across the new AI mods, so the AI features are discoverable in one place. Every pack is tagged with the new `ai` primary category (plus relevant secondaries like security, logging, data protection, access management).

## Packs by provider

- **AWS Bedrock (5):** model invocation logging, Guardrails content filtering, account-wide enforced guardrail, agent encryption at rest, API permissions lockdown
- **Azure AI Foundry (8):** encryption at rest, public network access disabled, local auth disabled, outbound FQDN allow-list, Responsible AI policy, allowed model names, model version pinning, connection auth types
- **GCP Vertex AI (3):** endpoint encryption (CMEK), endpoint request-response logging, deployment resource pool encryption (CMEK)
- **Anthropic (4):** workspace data residency, single billing owner, API key rotation, user email-domain allow-list
- **OpenAI (5):** Zero Data Retention attestation, approved models per project, API key rotation, admin API key rotation, user email-domain allow-list

## Conventions

- Each pack is the standard 4 files (`main.tf`, `policies.tf`, `providers.tf`, `README.md`), matching existing packs.
- Every policy-type URI and enum value was verified against the source mod YAML.
- Primary policies default to non-destructive `Check`, with `Enforce` options commented out.
- Environment-specific companions (KMS keys, guardrail IDs, logging destinations) are commented placeholders.
- `terraform fmt` clean across all packs.

A companion change in `hub.guardrails.turbot.com` adds the **AI** category to the filter UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)