### PR TITLE
feat: add Azure Search Service public network access policy pack

### DIFF
--- a/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/README.md
+++ b/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/README.md
@@ -1,0 +1,101 @@
+---
+categories: ["ai", "security", "networking"]
+primary_category: "ai"
+---
+
+# Enforce Public Network Access Is Disabled for Azure Search Services
+
+Azure AI Search (Search Management) search services can accept connections over the public internet by default. Disabling public network access ensures the search service is only reachable through private endpoints, which is the recommended posture for production AI and search workloads and significantly reduces the network attack surface.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Azure Search Management search services:
+
+- Check or enforce that public network access is disabled
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_searchmanagement_enforce_public_network_access_disabled_for_search_services/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-searchmanagement](https://hub.guardrails.turbot.com/mods/azure/mods/azure-searchmanagement)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_searchmanagement_search_service_public_network_access" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-searchmanagement#/policy/types/searchServicePublicNetworkAccess"
+  # value    = "Check: Disabled"
+  value    = "Enforce: Disabled"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/main.tf
+++ b/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Public Network Access Is Disabled for Azure Search Services"
+  description = "Reduce the network attack surface of Azure AI Search (Search Management) search services by requiring public network access to be disabled so the service is only reachable through private endpoints."
+  akas        = ["azure_searchmanagement_enforce_public_network_access_disabled_for_search_services"]
+}

--- a/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/policies.tf
+++ b/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/policies.tf
@@ -3,7 +3,5 @@ resource "turbot_policy_setting" "azure_searchmanagement_search_service_public_n
   resource = turbot_policy_pack.main.id
   type     = "tmod:@turbot/azure-searchmanagement#/policy/types/searchServicePublicNetworkAccess"
   value    = "Check: Disabled"
-  # value    = "Check: Enabled"
   # value    = "Enforce: Disabled"
-  # value    = "Enforce: Enabled"
 }

--- a/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/policies.tf
+++ b/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/policies.tf
@@ -1,0 +1,9 @@
+# Azure > Search Management > Search Service > Public Network Access
+resource "turbot_policy_setting" "azure_searchmanagement_search_service_public_network_access" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-searchmanagement#/policy/types/searchServicePublicNetworkAccess"
+  value    = "Check: Disabled"
+  # value    = "Check: Enabled"
+  # value    = "Enforce: Disabled"
+  # value    = "Enforce: Enabled"
+}

--- a/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/providers.tf
+++ b/policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
## What

Adds a new policy pack: **Enforce Public Network Access Is Disabled for Azure Search Services**.

```
policy_packs/azure/searchmanagement/enforce_public_network_access_disabled_for_search_services/
```

It checks/enforces that public network access is disabled on Azure AI Search (Search Management) search services, so they are only reachable through private endpoints.

## Why

The `azure-searchmanagement` v5.14.0 mod ([changelog](https://turbot.com/guardrails/changelog/azure-searchmanagement-v5-14-0)) introduced a new `Azure > Search Management > Search Service > Public Network Access` policy/control type. We already ship an analogous pack for AI Foundry accounts (`enforce_public_network_access_disabled_for_accounts`) but had no equivalent for Search Services — this fills that gap in the AI governance set.

## Implementation

Modeled 1:1 on the existing AI Foundry account pack, retargeted to the Search Service resource type:

```hcl
type  = "tmod:@turbot/azure-searchmanagement#/policy/types/searchServicePublicNetworkAccess"
value = "Check: Disabled"   # Enforce: Disabled provided commented-out
```

## ⚠️ Reviewer note

The policy type slug `searchServicePublicNetworkAccess` was inferred from the mod's naming convention (all other Search Service policies use the `searchService*` prefix; aifoundry uses `accountPublicNetworkAccess`). The workspace available for lookup was still on a pre-v5.14.0 version of the mod, so please confirm the exact slug against a workspace running v5.14.0 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)